### PR TITLE
feat(repo): introduce Dev Container configuration

### DIFF
--- a/.devcontainer/.zshrc
+++ b/.devcontainer/.zshrc
@@ -1,0 +1,24 @@
+# Prompt: green user, blue directory, reset
+PS1='%F{green}spirit-dev%f %F{blue}%~%f $ '
+
+# Enable colored output
+autoload -U colors && colors
+
+# Enable colored ls and grep
+alias ls='ls --color=auto'
+alias grep='grep --color=auto'
+
+# Persist zsh history
+export HISTFILE=/commandhistory/.zsh_history
+export HISTSIZE=10000
+export SAVEHIST=10000
+setopt APPEND_HISTORY
+setopt SHARE_HISTORY
+
+# Smart completion
+autoload -Uz compinit && compinit
+zstyle ':completion:*' menu select
+zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}' 'l:|=* r:|=*'
+
+# Add Claude Code to PATH
+export PATH="$HOME/.local/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Use the bookworm distribution as a base image since it already contains many dependencies required by Playwright.
-FROM node:20-bookworm
+FROM node:20
 
 # Set `DEVCONTAINER` environment variable to help with orientation
 ENV DEVCONTAINER=true
@@ -9,16 +9,12 @@ ARG USERNAME=node
 
 # Install basic development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  zsh \
   gh \
   jq \
-  nano \
   sudo \
   vim \
+  zsh \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install Playwright system dependencies (browsers are installed in postCreateCommand)
-RUN corepack enable && yarn dlx playwright install-deps chromium
 
 # Grant passwordless sudo to the non-root user
 RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USERNAME \
@@ -45,7 +41,6 @@ USER $USERNAME
 
 # Set the default shell to zsh rather than sh
 ENV SHELL=/bin/zsh
-COPY .zshrc /home/$USERNAME/.zshrc
 
 # Install Claude Code
 RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Ensure default user has access to /usr/local/share
+# Ensure default user has access to /usr/local/share and /usr/local/bin (for corepack symlinks)
 RUN mkdir -p /usr/local/share/npm-global && \
-  chown -R $USERNAME:$USERNAME /usr/local/share
+  chown -R $USERNAME:$USERNAME /usr/local/share /usr/local/bin
 
 # Persist bash history
 RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,54 @@
+# Use the bookworm distribution as a base image since it already contains many dependencies required by Playwright.
+FROM node:20-bookworm
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Non-root user name
+ARG USERNAME=node
+
+# Install basic development tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  zsh \
+  gh \
+  jq \
+  nano \
+  sudo \
+  vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Playwright system dependencies (browsers are installed in postCreateCommand)
+RUN corepack enable && yarn dlx playwright install-deps chromium
+
+# Grant passwordless sudo to the non-root user
+RUN echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USERNAME \
+  && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Ensure default user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R $USERNAME:$USERNAME /usr/local/share
+
+# Persist bash history
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME:$USERNAME /commandhistory
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace/node_modules /workspace/.yarn/cache /home/$USERNAME/.claude /home/$USERNAME/.cache/node/corepack && \
+  chown -R $USERNAME:$USERNAME /workspace /home/$USERNAME/.claude /home/$USERNAME/.cache
+
+WORKDIR /workspace
+
+# Switch to the non-root user
+USER $USERNAME
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+COPY .zshrc /home/$USERNAME/.zshrc
+
+# Install Claude Code
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Install Open Code
+RUN curl -fsSL https://opencode.ai/install | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "dockerfile": "Dockerfile"
   },
 
-  "postCreateCommand": "corepack install && yarn install && yarn playwright install chromium",
+  "postCreateCommand": "corepack enable && corepack install && yarn install && yarn playwright install --with-deps chromium",
   "postStartCommand": "sudo chown -R $(id -u):$(id -g) /workspace/node_modules /workspace/.yarn/cache",
 
   "appPort": ["3456:3456", "6006:6006", "9323:9323"],
@@ -29,7 +29,8 @@
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
     "source=${localWorkspaceFolderBasename}-yarn-cache,target=${containerWorkspaceFolder}/.yarn/cache,type=volume",
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=${localWorkspaceFolder}/.devcontainer/.zshrc,target=/home/node/.zshrc,type=bind"
   ],
 
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,11 @@
 {
   "name": "Spirit Design System",
-  "image": "node:20-bookworm",
-
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+  "build": {
+    "dockerfile": "Dockerfile"
   },
 
-  "postCreateCommand": "corepack enable && corepack install && yarn install && npx playwright install --with-deps chromium",
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postCreateCommand": "corepack install && yarn install && yarn playwright install chromium",
+  "postStartCommand": "sudo chown -R $(id -u):$(id -g) /workspace/node_modules /workspace/.yarn/cache",
 
   "appPort": ["3456:3456", "6006:6006", "9323:9323"],
   "forwardPorts": [3456, 6006, 9323],
@@ -23,13 +21,19 @@
     }
   },
 
+  "remoteUser": "node",
+
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${containerWorkspaceFolder},type=bind,consistency=delegated",
   "mounts": [
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
-    "source=${localWorkspaceFolderBasename}-yarn-cache,target=/home/node/.yarn/berry/cache,type=volume"
+    "source=${localWorkspaceFolderBasename}-yarn-cache,target=${containerWorkspaceFolder}/.yarn/cache,type=volume",
+    "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
   ],
 
-  "remoteEnv": {
-    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
-    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}"
+  "containerEnv": {
+    "NODE_OPTIONS": "--max-old-space-size=4096",
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude"
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "Spirit Design System",
+  "image": "node:20-bookworm",
+
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "postCreateCommand": "corepack enable && corepack install && yarn install && npx playwright install --with-deps chromium",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+
+  "appPort": ["3456:3456", "6006:6006", "9323:9323"],
+  "forwardPorts": [3456, 6006, 9323],
+  "portsAttributes": {
+    "3456": {
+      "label": "Vite Dev Server"
+    },
+    "6006": {
+      "label": "Storybook"
+    },
+    "9323": {
+      "label": "Playwright UI"
+    }
+  },
+
+  "mounts": [
+    "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+    "source=${localWorkspaceFolderBasename}-yarn-cache,target=/home/node/.yarn/berry/cache,type=volume"
+  ],
+
+  "remoteEnv": {
+    "ANTHROPIC_API_KEY": "${localEnv:ANTHROPIC_API_KEY}",
+    "OPENAI_API_KEY": "${localEnv:OPENAI_API_KEY}"
+  }
+}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Get Playwright Version
         id: playwright-version
         run: |
-          PW_VERSION=$(node -p "require('./package.json').devDependencies['@playwright/test']")
+          PW_VERSION=$(jq -r '.devDependencies["@playwright/test"]' package.json)
           echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Run Playwright tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -65,8 +65,14 @@ jobs:
           NETLIFY_DEPLOYED_URL: ${{ env.PR_NUMBER && env.NETLIFY_DEPLOY_PREVIEW_URL || env.NETLIFY_MAIN_URL }}
         run: echo "site_url=${{ env.NETLIFY_DEPLOYED_URL }}" >> "$GITHUB_OUTPUT"
 
+      - name: Get Playwright Version
+        id: playwright-version
+        run: |
+          PW_VERSION=$(node -p "require('./package.json').devDependencies['@playwright/test']")
+          echo "version=$PW_VERSION" >> $GITHUB_OUTPUT
+
       - name: Run Playwright tests
-        uses: docker://mcr.microsoft.com/playwright:v1.56.0-noble
+        uses: docker://mcr.microsoft.com/playwright:v${{ steps.playwright-version.outputs.version }}-noble
         with:
           args: 'sh -c "corepack install && corepack enable && yarn test:e2e"'
         env:

--- a/.prettierignore
+++ b/.prettierignore
@@ -111,3 +111,5 @@ Caddyfile
 .gitattributes
 
 /.nx/workspace-data
+
+.zshrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Here are some tips how to make your contributing efforts efficient and eventuall
 - [Decisions](#decisions)
 - [Project Structure](#project-structure)
 - [Development](#development)
+- [Dev Containers (Experimental)](#dev-containers-experimental)
 - [Commit Conventions](#commit-conventions)
 - [Code Style](#code-style)
 - [Documenting the Components](#documenting-the-components)
@@ -29,6 +30,63 @@ This project is a monorepo managed by [Lerna][lerna-home]. This means that each 
 ## Development
 
 See [Developer Handbook][developer-handbook] for more information about development.
+
+## Dev Containers (Experimental)
+
+This project supports [Dev Containers][dev-containers] for a consistent, containerized development environment.
+
+### Prerequisites
+
+- [Docker Desktop][docker]
+- IDE with Dev Container support (VS Code, JetBrains, etc.)
+
+### Getting Started
+
+1. Open the project in your IDE
+2. Use the "Reopen in Container" option
+3. Wait for the container to build and dependencies to install
+4. Run `make help` to see available commands
+
+The container automatically:
+
+- Installs all project dependencies via [Yarn][yarn]
+- Installs [Playwright][playwright] Chromium browser for E2E testing
+- Installs [GitHub CLI][github-cli] (`gh`) for PR workflows
+- Forwards ports for Vite web server (3456), Storybook (6006), and Playwright UI (9323)
+
+### Running E2E Tests
+
+Since Playwright is installed in the dev container, you can run end-to-end tests directly:
+
+```bash
+yarn test:e2e         # Run all E2E tests
+yarn test:e2e:update  # Run all E2E tests and update snapshots
+yarn test:e2e:ui      # Run with Playwright UI
+```
+
+### Using AI Tools
+
+The Dev Container supports AI-powered coding assistants. You can use tools like [Cursor][cursor], [Claude Code][claude-code],
+[Open Code][open-code], or any other AI coding tool that integrates with Dev Containers.
+
+#### API Keys
+
+The Dev Container is configured to pass through common AI tool API keys from your local machine via the `remoteEnv` setting:
+
+- `ANTHROPIC_API_KEY` — for Claude-based tools (Claude Code, Cursor with Claude, etc.)
+- `OPENAI_API_KEY` — for OpenAI-based tools
+
+Set these environment variables on your local machine before starting the Dev Container:
+
+```bash
+export ANTHROPIC_API_KEY=your-anthropic-api-key
+export OPENAI_API_KEY=your-openai-api-key
+```
+
+#### Installing CLI Tools
+
+Some AI tools like [Claude Code][claude-code] or [Open Code][open-code] are CLI applications that need to be installed
+**inside the dev container**. Refer to their documentation for installation instructions.
 
 ## Commit Conventions
 
@@ -382,10 +440,13 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 > If you have further questions do not hesitate to open an issue and ask us! ❤️
 
 [act]: https://github.com/nektos/act
+[claude-code]: https://docs.anthropic.com/en/docs/claude-code
+[cursor]: https://www.cursor.com/
 [act-article]: https://www.freecodecamp.org/news/how-to-run-github-actions-locally/
 [conventional-commits]: https://www.conventionalcommits.org
 [commitlint-config]: https://github.com/lmc-eu/code-quality-tools/tree/main/packages/commitlint-config
 [decisions]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/decisions/README.md
+[dev-containers]: https://containers.dev/
 [developer-handbook]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/contribution/development.md
 [dictionary]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md
 [docker]: https://www.docker.com/
@@ -393,6 +454,7 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [jest]: https://jestjs.io/
 [lerna-home]: https://lerna.js.org
 [netlify-preview-gist]: https://gist.github.com/adamkudrna/694f3048c1338f07375b9b8af24afe2f
+[open-code]: https://github.com/anthropics/opencode
 [packages]: packages/
 [playwright]: https://playwright.dev/
 [prettier]: https://prettier.io/
@@ -404,4 +466,6 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [figma-code-connect]: https://developers.figma.com/docs/code-connect/
 [figma-dev-mode]: https://help.figma.com/hc/en-us/articles/15023124644247-Guide-to-Dev-Mode
 [figma-react-guide]: https://developers.figma.com/docs/code-connect/react/
+[github-cli]: https://cli.github.com/
 [version-action]: https://github.com/lmc-eu/spirit-design-system/actions/workflows/version.yaml
+[yarn]: https://yarnpkg.com/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Here are some tips how to make your contributing efforts efficient and eventuall
 - [Decisions](#decisions)
 - [Project Structure](#project-structure)
 - [Development](#development)
-- [Dev Containers (Experimental)](#dev-containers-experimental)
+- [Dev Containers (Experimental)][dev-containers-docs]
 - [Commit Conventions](#commit-conventions)
 - [Code Style](#code-style)
 - [Documenting the Components](#documenting-the-components)
@@ -30,63 +30,6 @@ This project is a monorepo managed by [Lerna][lerna-home]. This means that each 
 ## Development
 
 See [Developer Handbook][developer-handbook] for more information about development.
-
-## Dev Containers (Experimental)
-
-This project supports [Dev Containers][dev-containers] for a consistent, containerized development environment.
-
-### Prerequisites
-
-- [Docker Desktop][docker]
-- IDE with Dev Container support (VS Code, JetBrains, etc.)
-
-### Getting Started
-
-1. Open the project in your IDE
-2. Use the "Reopen in Container" option
-3. Wait for the container to build and dependencies to install
-4. Run `make help` to see available commands
-
-The container automatically:
-
-- Installs all project dependencies via [Yarn][yarn]
-- Installs [Playwright][playwright] Chromium browser for E2E testing
-- Installs [GitHub CLI][github-cli] (`gh`) for PR workflows
-- Forwards ports for Vite web server (3456), Storybook (6006), and Playwright UI (9323)
-
-### Running E2E Tests
-
-Since Playwright is installed in the dev container, you can run end-to-end tests directly:
-
-```bash
-yarn test:e2e         # Run all E2E tests
-yarn test:e2e:update  # Run all E2E tests and update snapshots
-yarn test:e2e:ui      # Run with Playwright UI
-```
-
-### Using AI Tools
-
-The Dev Container supports AI-powered coding assistants. You can use tools like [Cursor][cursor], [Claude Code][claude-code],
-[Open Code][open-code], or any other AI coding tool that integrates with Dev Containers.
-
-#### API Keys
-
-The Dev Container is configured to pass through common AI tool API keys from your local machine via the `remoteEnv` setting:
-
-- `ANTHROPIC_API_KEY` — for Claude-based tools (Claude Code, Cursor with Claude, etc.)
-- `OPENAI_API_KEY` — for OpenAI-based tools
-
-Set these environment variables on your local machine before starting the Dev Container:
-
-```bash
-export ANTHROPIC_API_KEY=your-anthropic-api-key
-export OPENAI_API_KEY=your-openai-api-key
-```
-
-#### Installing CLI Tools
-
-Some AI tools like [Claude Code][claude-code] or [Open Code][open-code] are CLI applications that need to be installed
-**inside the dev container**. Refer to their documentation for installation instructions.
 
 ## Commit Conventions
 
@@ -440,13 +383,11 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 > If you have further questions do not hesitate to open an issue and ask us! ❤️
 
 [act]: https://github.com/nektos/act
-[claude-code]: https://docs.anthropic.com/en/docs/claude-code
-[cursor]: https://www.cursor.com/
 [act-article]: https://www.freecodecamp.org/news/how-to-run-github-actions-locally/
 [conventional-commits]: https://www.conventionalcommits.org
 [commitlint-config]: https://github.com/lmc-eu/code-quality-tools/tree/main/packages/commitlint-config
 [decisions]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/decisions/README.md
-[dev-containers]: https://containers.dev/
+[dev-containers-docs]: https://github.com/lmc-eu/spirit-design-system/blob/main/docs/contribution/dev-containers.md
 [developer-handbook]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/contribution/development.md
 [dictionary]: https://github.com/lmc-eu/spirit-design-system/tree/main/docs/DICTIONARIES.md
 [docker]: https://www.docker.com/
@@ -454,7 +395,6 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [jest]: https://jestjs.io/
 [lerna-home]: https://lerna.js.org
 [netlify-preview-gist]: https://gist.github.com/adamkudrna/694f3048c1338f07375b9b8af24afe2f
-[open-code]: https://github.com/anthropics/opencode
 [packages]: packages/
 [playwright]: https://playwright.dev/
 [prettier]: https://prettier.io/
@@ -466,6 +406,4 @@ After the release notes are ready, you can publish them (copy&paste from canvas)
 [figma-code-connect]: https://developers.figma.com/docs/code-connect/
 [figma-dev-mode]: https://help.figma.com/hc/en-us/articles/15023124644247-Guide-to-Dev-Mode
 [figma-react-guide]: https://developers.figma.com/docs/code-connect/react/
-[github-cli]: https://cli.github.com/
 [version-action]: https://github.com/lmc-eu/spirit-design-system/actions/workflows/version.yaml
-[yarn]: https://yarnpkg.com/

--- a/docs/contribution/dev-containers.md
+++ b/docs/contribution/dev-containers.md
@@ -1,0 +1,113 @@
+# Dev Containers (Experimental)
+
+This project supports [Dev Containers][dev-containers] for a consistent, containerized development environment.
+
+- [Prerequisites](#prerequisites)
+- [Container Image](#container-image)
+- [Getting Started](#getting-started)
+- [SSH](#ssh)
+- [Git](#git)
+- [Running E2E Tests](#running-e2e-tests)
+- [Using AI Tools](#using-ai-tools)
+
+## Prerequisites
+
+- [Docker][docker]
+- IDE with Dev Container support:
+  - **VS Code:** [Dev Containers][vsc-dev-containers] extension
+  - **JetBrains IDEs:** [Remote Development][jetbrains-remote-development] plugin (bundled, but must be enabled)
+
+## Container Image
+
+- **Base image:** [`node:20-bookworm`][node-image] — [Debian 12 (Bookworm)][bookworm] with:
+  - Node.js 20 LTS
+  - OS dependencies required by Playwright
+  - Git
+  - Make
+  - curl
+  - etc.
+- **Custom Dockerfile:** extends the base image with [Corepack][corepack], [Playwright][playwright] Chromium (+ OS dependencies), and Git safe-directory config pre-baked into the image
+- **Dev Container features:** [GitHub CLI][github-cli] (`gh`)
+- **Tools installed at build time (Dockerfile):**
+  - [Corepack][corepack] (enables Yarn)
+  - [Playwright][playwright] OS dependencies (E2E testing)
+- **Tools installed upon container creation (`postCreateCommand`):**
+  - [Yarn][yarn] project dependencies
+  - [Playwright][playwright] Chromium browser
+
+The container automatically forwards ports for:
+
+- Vite web server (3456)
+- Storybook (6006)
+- Playwright UI (9323)
+
+## Getting Started
+
+1. Open the project in your IDE
+2. Use the "Reopen in Container" option
+3. Wait for the container to build and dependencies to install
+4. Run `make help` to see available commands
+
+## SSH
+
+### VS Code
+
+In VS Code, your local SSH agent is automatically forwarded to the container.
+No additional configuration is required.
+
+### JetBrains IDEs
+
+As we consider forwarding SSH to be a security risk, we do not forward SSH
+to the container by default. This may change in the future.
+
+## Git
+
+Your Git user name and email are automatically configured inside the container.
+Futhermore, GitHub CLI (`gh`) is installed inside the container and can be used
+to authenticate with GitHub CLI inside the container.
+
+### VS Code
+
+Your local [SSH](#ssh) agent is automatically forwarded to the container, so
+you can use Git commands without any additional configuration.
+
+### JetBrains IDEs
+
+Run `gh auth login` to authenticate with GitHub CLI inside the container.
+
+## Running E2E Tests
+
+Since Playwright is installed in the dev container, you can run end-to-end tests directly:
+
+```bash
+yarn test:e2e         # Run all E2E tests
+yarn test:e2e:update  # Run all E2E tests and update snapshots
+yarn test:e2e:ui      # Run with Playwright UI
+```
+
+## Using AI Tools
+
+The Dev Container supports AI-powered coding assistants. You can use tools like [Cursor][cursor], [Claude Code][claude-code],
+[Open Code][open-code], or any other AI coding tool that integrates with Dev Containers.
+
+### Authentication
+
+Each AI tool has its own authentication method. Refer to the tool's documentation for setup instructions:
+
+- [Claude Code][claude-code]
+- [Open Code][open-code]
+- [Cursor][cursor]
+
+[claude-code]: https://docs.anthropic.com/en/docs/claude-code
+[cursor]: https://www.cursor.com/
+[dev-containers]: https://containers.dev/
+[docker]: https://www.docker.com/
+[github-cli]: https://cli.github.com/
+[open-code]: https://github.com/anthropics/opencode
+[bookworm]: https://www.debian.org/releases/bookworm/
+[corepack]: https://nodejs.org/api/corepack.html
+[node-image]: https://hub.docker.com/_/node
+[playwright]: https://playwright.dev/
+[jetbrains-remote-development]: https://www.jetbrains.com/help/idea/remote-development-overview.html
+[vsc-dev-containers]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+[yarn]: https://yarnpkg.com/


### PR DESCRIPTION
## Description

Introduce Dev Container configuration to enable a consistent, containerized development environment for the Spirit Design System.

**This is an experimental feature** — feedback and improvements are welcome.

The Dev Container setup includes:
- Node.js 20 base image
- Automatic dependency installation via Yarn
- Playwright Chromium browser for E2E testing
- GitHub CLI for PR workflows
- Port forwarding for Vite (3456), Storybook (6006), and Playwright UI (9323)
- Volume mounts for `node_modules` and Yarn cache to improve performance
- Pre-installed AI tools: Claude Code, Open Code

Also includes a CI improvement: the Playwright Docker image version is now read dynamically from `package.json` instead of being hardcoded.

### Additional context

The Dev Container feature is marked as experimental in the documentation. As of now, it has been tested with JetBrains PhpStorm only, but it should work with other IDEs that support the Dev Containers specification (VS Code, other JetBrains IDEs, etc.).

### Issue reference

https://jira.almacareer.tech/browse/DS-2371