### PR TITLE
docs(repo): introduce typescript review skill

### DIFF
--- a/.agents/skills/typescript/README.md
+++ b/.agents/skills/typescript/README.md
@@ -1,0 +1,20 @@
+# TypeScript
+
+TypeScript review knowledge for the Spirit `web-react` package and `.ts` tooling.
+
+## Purpose
+
+Focuses on type design rather than syntax: making invalid states unrepresentable, avoiding `any` abuse
+and stringly-typed APIs, treating public component prop types as API surface, and precise element-prop
+extension. Focuses on what the compiler and ESLint cannot catch.
+
+## Usage
+
+Loaded (via `cat`) by the `frontend-reviewer` alongside `spirit:react`,
+`spirit:design-system`, and the code-review methodology. Invoke `/spirit:typescript` to apply this lens
+directly when reviewing only TypeScript.
+
+## Related Skills
+
+- `spirit:react` — paired component lens.
+- `spirit:design-system` — Spirit API and prop conventions.

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: spirit:typescript
+description: >-
+  TypeScript review knowledge for the Spirit Design System — type-design quality, making invalid
+  states unrepresentable, public component-prop typing, and type anti-patterns. Loaded by the
+  web-react reviewer; standalone-invokable when reviewing only TypeScript. Use when reviewing
+  or building typed Spirit code.
+---
+
+# TypeScript (Spirit)
+
+Review knowledge for the type layer of `packages/web-react` (and any `.ts` tooling). Pairs with
+`spirit:react`. Report only what the compiler and ESLint cannot already catch (see
+the code-review methodology) — focus on **type design**, not syntax.
+
+## Make Invalid States Unrepresentable
+
+- **Discriminated unions over boolean soup** — variant props with mutually exclusive shapes should
+  be a union, not several independent optional fields that allow nonsensical combinations.
+- **Encapsulation** — hide implementation detail behind the public type; do not leak internal
+  structures consumers should not depend on.
+- **No exposed mutable internals** — returning an internal array/object that callers can mutate is a
+  bug surface; return readonly types or copies.
+
+## Type Anti-Patterns to Flag
+
+- **`any` abuse** — `any` used to silence the compiler instead of modeling the type. Prefer
+  `unknown` + narrowing, generics, or a precise type.
+- **Stringly-typed APIs** — `string` where a union literal or finite set is meant (e.g. a `variant`
+  prop typed `string`).
+- **God objects** — prop/config types with many unrelated fields that should be decomposed.
+- **Type assertions (`as`) hiding mismatches** — assertions that paper over a real type error rather
+  than a genuine narrowing the compiler cannot infer.
+- **Non-null assertions (`!`)** on values that can legitimately be null.
+
+## Component Prop Typing
+
+- **Public prop types are API.** Component prop interfaces are part of the published surface — they
+  must be exported, named consistently, and documented. A breaking change to a prop type is a
+  breaking change to the package.
+- Keep public types in the component's `types.ts` per Spirit convention.
+- Prefer precise element-prop extension (e.g. extending the right intrinsic element's attributes) so
+  consumers get correct `aria-*`/`data-*`/event typings, supporting the `restProps` spread in
+  `spirit:react`.
+- Use `import type` for type-only imports to keep the boundary clear.
+
+## Comments
+
+- JSDoc on complex public types/logic helps consumers; flag misleading or stale type comments.


### PR DESCRIPTION
## Description

Part of splitting the agentic code-review rework (umbrella: #2581) into one reviewable skill per PR.

Introduces the `typescript` knowledge skill — type-design quality: making invalid states unrepresentable, treating public prop types as API, and type anti-patterns. Standalone-runnable, loaded by the code-review reviewers via `cat`.

### Additional context

Draft, part of a series split out of #2581. The skills are interdependent; see #2581 for the full picture and the sibling per-skill PRs.
