### PR TITLE
docs(repo): introduce scss review skill

### DIFF
--- a/.agents/skills/scss/README.md
+++ b/.agents/skills/scss/README.md
@@ -1,0 +1,20 @@
+# SCSS
+
+SCSS/CSS review knowledge for the Spirit `web` package.
+
+## Purpose
+
+Covers the conventions Stylelint cannot enforce: tokens over hardcoded values, reuse of existing
+mixins/functions/components, unit tests for custom mixins and functions, separation of concerns (no
+styling one component from another), BEM/SUIT naming, and breakpoint tokens for responsiveness.
+
+## Usage
+
+Loaded (via `cat`) by the `frontend-reviewer` alongside `spirit:html`, `spirit:design-system`, and
+the code-review methodology. Invoke `/spirit:scss` to apply this lens directly when reviewing only styles.
+
+## Related Skills
+
+- `spirit:html` — paired markup lens.
+- `spirit:design-system` — token structure and theming rules.
+- `spirit:accessibility` — contrast and focus-ring concerns.

--- a/.agents/skills/scss/SKILL.md
+++ b/.agents/skills/scss/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: spirit:scss
+description: >-
+  SCSS/CSS review knowledge for the Spirit Design System web package — token usage over hardcoded
+  values, mixin/function reuse and unit tests, separation of concerns, and BEM/SUIT naming. Loaded by
+  the web reviewer; standalone-invokable when reviewing only styles. Use when reviewing or building
+  Spirit SCSS.
+---
+
+# SCSS (Spirit Web)
+
+Review knowledge for `packages/web` styles. Defers all token _structure_ and theming rules to
+`spirit:design-system` and visual a11y (contrast, focus ring) to
+`spirit:accessibility`. Report only what Stylelint (`stylelint-config-spirit`) cannot catch (see
+the code-review methodology) — focus on the conventions below, which are not lintable.
+
+## Tokens Over Hardcoded Values
+
+- Raw colors, spacing, radii, shadows, typography, z-index, or breakpoints in component SCSS are a
+  finding — there is a token for it. See the token structure in
+  `spirit:design-system`.
+- A value wedged off the token scale (e.g. a one-off `13px`) signals either a missing token or a
+  design drift — ask rather than assert if intent is unclear.
+
+## Reuse Over Reinvention
+
+- **Use existing mixins, functions, and helpers** instead of re-implementing equivalent logic.
+  Before flagging, check whether a suitable tool/mixin already exists in the `tools/`/`helpers/`
+  layers.
+- **Use existing components/placeholders** rather than duplicating their styles inline.
+
+## Test Custom Mixins & Functions
+
+- Every custom SCSS mixin or function should be covered by a unit test (Spirit keeps
+  `__tests__/_*.test.scss` alongside the tools). A new mixin/function without a test is a `todo`.
+
+## Separation of Concerns
+
+- A component must not style another component. Do not reach across and style component B from
+  component A's stylesheet (e.g. targeting `.OtherComponent` inside `_Component.scss`). Layout
+  relationships belong to layout primitives or explicit composition, not cross-component selectors.
+- Keep specificity flat; avoid deep descendant chains that leak into children's internals.
+
+## Naming & Structure
+
+- **BEM/SUIT**: `.Component`, `.Component--modifier`, `.Component__element` (see
+  `spirit:design-system`).
+- SCSS partials use the underscore prefix (`_Button.scss`).
+- Avoid deep nesting (>3 levels) — it inflates specificity and obscures the generated selector.
+- No brightness-implying names (`-light`, `-dark`, `-inverted`) — use neutral tokens/themes.
+
+## Responsiveness
+
+- Use the design system's breakpoint tokens/mixins rather than ad-hoc media queries with raw widths.


### PR DESCRIPTION
## Description

Part of splitting the agentic code-review rework (umbrella: #2581) into one reviewable skill per PR.

Introduces the `scss` knowledge skill — tokens over hardcoded values, mixin/function reuse and unit tests, separation of concerns, and BEM/SUIT naming. Standalone-runnable, loaded by the code-review reviewers via `cat`.

### Additional context

Draft, part of a series split out of #2581. The skills are interdependent; see #2581 for the full picture and the sibling per-skill PRs.
