### PR TITLE
docs(repo): introduce html review skill

### DIFF
--- a/.agents/skills/html/README.md
+++ b/.agents/skills/html/README.md
@@ -1,0 +1,19 @@
+# HTML
+
+HTML/markup review knowledge for the Spirit `web` package.
+
+## Purpose
+
+Covers correct semantic markup — the right element for the purpose (`button` vs `a`), document and
+landmark structure, heading order, form markup, and attribute hygiene. The deeper ARIA, keyboard, and
+assistive-technology concerns live in `spirit:accessibility`.
+
+## Usage
+
+Loaded (via `cat`) by the `frontend-reviewer` alongside `spirit:scss`, `spirit:design-system`, and
+the code-review methodology. Invoke `/spirit:html` to apply this lens directly when reviewing only markup.
+
+## Related Skills
+
+- `spirit:accessibility` — ARIA, keyboard, and screen-reader depth.
+- `spirit:scss` — paired styling lens.

--- a/.agents/skills/html/SKILL.md
+++ b/.agents/skills/html/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: spirit:html
+description: >-
+  HTML/markup review knowledge for the Spirit Design System web package — semantic elements, document
+  structure, correct element-for-purpose, and form markup. Loaded by the web reviewer;
+  standalone-invokable when reviewing only markup. Use when reviewing or building Spirit HTML.
+---
+
+# HTML (Spirit Web)
+
+Markup review knowledge for `packages/web` (and the HTML structure React renders). The ARIA,
+keyboard, and assistive-technology depth lives in `spirit:accessibility`; this skill covers correct
+semantic markup, which is the foundation a11y builds on. Report only what linters cannot catch (see
+the code-review methodology).
+
+## Use the Right Element
+
+- **`button` for actions, `a[href]` for navigation.** A clickable `div`/`span` is a finding — it
+  loses keyboard operability and semantics for free with the native element.
+- Use native form controls (`input`, `select`, `textarea`, `label`) rather than re-implementing them.
+- Lists are `ul`/`ol`/`li`; tabular data is a `table` with `th`/`scope`, not a grid of divs.
+
+## Document & Landmark Structure
+
+- One logical `h1` per page/region; heading levels do not skip (no `h2` → `h4`).
+- Landmark elements (`header`, `nav`, `main`, `footer`, `aside`, `section`) over generic `div`s where
+  a landmark applies.
+- Order DOM in reading order; do not rely on CSS to reorder meaningful content.
+
+## Forms
+
+- Every control has an associated `<label>` (wrapping or `for`/`id`); placeholders are not labels.
+- Group related fields with `fieldset`/`legend`.
+- Use appropriate `type`, `name`, and `autocomplete` attributes.
+- (Programmatic error association and announcements: see `spirit:accessibility`.)
+
+## Attributes & Hygiene
+
+- `id` values are unique within the document.
+- Boolean attributes (`disabled`, `required`, `readonly`) are used as booleans, not string values.
+- Images have meaningful `alt`, or empty `alt` when decorative (see `spirit:accessibility`).


### PR DESCRIPTION
## Description

Part of splitting the agentic code-review rework (umbrella: #2581) into one reviewable skill per PR.

Introduces the `html` knowledge skill — the right element for the purpose, landmark structure, forms, and attribute hygiene. Standalone-runnable, loaded by the code-review reviewers via `cat`.

### Additional context

Draft, part of a series split out of #2581. The skills are interdependent; see #2581 for the full picture and the sibling per-skill PRs.
