### PR TITLE
docs(repo): introduce accessibility skill

### DIFF
--- a/.agents/skills/accessibility/README.md
+++ b/.agents/skills/accessibility/README.md
@@ -1,0 +1,12 @@
+# Accessibility
+
+Accessibility (a11y) knowledge, a first-class lens for a design system.
+
+## Purpose
+
+Covers semantics-first markup, correct ARIA, keyboard operability and focus management, the
+`focus-ring` token and `:focus-visible`, forms, color/motion, screen-reader content (`VisuallyHidden`),
+and the repo's a11y test infrastructure. Targets WCAG 2.2 AA. Spans React, HTML, and SCSS together,
+so it catches issues a single-technology lens cannot. The actionable detail lives in
+`references/accessibility-checklist.md`; worked, Spirit-adapted code examples live in
+`references/accessibility-patterns.md`.

--- a/.agents/skills/accessibility/README.md
+++ b/.agents/skills/accessibility/README.md
@@ -1,0 +1,43 @@
+# Accessibility Skill
+
+Applies the Spirit accessibility review lens — semantics-first markup, ARIA, keyboard operability,
+focus management, forms, contrast, motion, and screen-reader content. Targets WCAG 2.2 AA.
+Spans React, vanilla HTML, and SCSS.
+
+## Usage
+
+Invoked automatically when adding or reviewing Spirit components. Also triggered by phrases like
+"improve accessibility", "a11y audit", "WCAG compliance", "screen reader support", "keyboard
+navigation", or "make accessible".
+
+Or explicitly:
+
+```text
+/spirit:accessibility
+```
+
+## What It Does
+
+1. Loads the Spirit-specific [accessibility checklist](references/accessibility-checklist.md)
+   covering keyboard navigation, screen readers, visual, forms, ARIA live regions, and common
+   anti-patterns.
+2. Loads [accessibility code patterns](references/accessibility-patterns.md) — worked examples using
+   Spirit primitives (`VisuallyHidden`, `$focus-ring`, SCSS a11y mixins).
+3. Applies the checklist as a review lens: flags regressions as **blocking**; other issues as
+   `todo` or `suggestion`.
+
+## What It Does Not Do
+
+- **Cannot run automated tests** — does not execute Lighthouse, axe-core, or any test suite.
+  Run `yarn dlx lighthouse <url>` or `yarn dlx @axe-core/cli <url>` for an automated pass.
+- **Cannot replace manual testing** — screen reader (VoiceOver / NVDA), 200% zoom, and
+  `prefers-reduced-motion` checks require a real browser session.
+- **Does not check design tokens** — contrast is the designer's responsibility; the skill only
+  flags hardcoded color values that bypass the token system.
+
+## Reference Files
+
+| File                                                                             | Contents                                                                                        |
+| -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [`references/accessibility-checklist.md`](references/accessibility-checklist.md) | Actionable WCAG 2.2 AA checklist — keyboard, screen readers, visual, forms, ARIA, anti-patterns |
+| [`references/accessibility-patterns.md`](references/accessibility-patterns.md)   | Spirit-adapted code patterns with worked examples                                               |

--- a/.agents/skills/accessibility/SKILL.md
+++ b/.agents/skills/accessibility/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: spirit:accessibility
+description: >-
+  Audit and improve web accessibility, semantics, ARIA, keyboard
+  operability, focus management, contrast, following WCAG 2.2 guidelines. Always apply when adding or reviewing Spirit components and features. Also triggered by "improve accessibility", "a11y audit", "WCAG compliance", "screen reader support", "keyboard navigation", or "make accessible".
+---
+
+# Accessibility
+
+Accessibility is a primary review lens for Spirit — design-system components are consumed everywhere,
+so an a11y regression multiplies. Target **WCAG 2.2 AA**. Spans React (`.tsx`), vanilla HTML, and
+SCSS.
+
+WCAG is organized around four principles — content must be **P**erceivable, **O**perable,
+**U**nderstandable, and **R**obust — across three conformance levels (A, **AA** ← our target, AAA).
+The sections below map to how the work shows up in Spirit; WCAG success-criterion numbers (e.g.
+`2.5.8`) are cited inline so a finding can point at the exact criterion.
+
+A **blocking** finding is appropriate when a change removes or breaks accessibility that previously
+worked (keyboard trap, lost focus, missing accessible name on an interactive control).
+
+## Semantics First, ARIA Second
+
+- Prefer native semantic elements (`button`, `a`, `input`, `nav`, `ul`) over `div`/`span` with
+  added ARIA. ARIA is a fallback, not a default.
+- **No redundant or conflicting ARIA** — e.g. `role="button"` on a `<button>`, or an `aria-label`
+  that contradicts visible text.
+- Every interactive control needs an **accessible name** (visible label, `aria-label`, or
+  `aria-labelledby`) — name/role/value (`4.1.2`). Icon-only controls must have a name.
+
+## Keyboard & Focus
+
+- All interactive elements must be **operable by keyboard** (`2.1.1`): Tab to reach, Enter/Space to
+  activate, Escape to dismiss overlays where expected.
+- **No keyboard traps** (`2.1.2`); focus order follows visual order (`2.4.3`).
+- **Manage focus** for overlays/dialogs/menus: move focus in on open, restore it on close, and trap
+  it within modal surfaces.
+- **Visible focus indicator** (`2.4.7`) — never remove the focus outline without an equivalent; use
+  the design system's focus-ring token. `:focus-visible` is preferred over `:focus` for pointer
+  interactions.
+- **Focus not obscured** (`2.4.11`) — when an element takes focus it must not be fully
+  hidden by sticky headers/footers or overlapping panels; reserve space with `scroll-margin`.
+
+## Forms
+
+- Every input has an associated `<label>` (or equivalent). Placeholder text is not a label.
+- Errors are associated programmatically (`aria-describedby`) and announced; validation state is not
+  conveyed by color alone.
+- Group related controls with `fieldset`/`legend`.
+
+## Visual & Motion
+
+- **Color is not the only signal** (`1.4.1`) — state/meaning must also be conveyed non-visually.
+- Contrast must meet AA (`1.4.3`: 4.5:1 text, 3:1 large text & UI components); rely on the design
+  tokens, which are designed to pass.
+- **Target size** (`2.5.8`) — interactive targets are at least 24×24 CSS px, unless an
+  inline link, browser-sized, or sufficiently spaced. Aim larger (44×44) for primary actions.
+- **Dragging movements** (`2.5.7`) — any drag action has a single-pointer alternative
+  (e.g. buttons, an input).
+- Respect `prefers-reduced-motion` for animation (`2.3.3`).
+
+## Content for Assistive Tech
+
+- Use a visually-hidden utility for screen-reader-only text rather than `display:none`, which
+  removes content from the accessibility tree. Spirit provides `VisuallyHidden` in React and the
+  `.accessibility-hidden` helper class in vanilla CSS.
+- Decorative images/icons are hidden from AT (`aria-hidden`/empty `alt`); meaningful ones have text
+  alternatives.
+- Dynamic updates that must be announced use an appropriate live region (`4.1.3`).
+
+## Beyond the Component
+
+A few new 2.2 success criteria are **application-level** and rarely actionable on an isolated
+component — note them for consumers but don't force them onto a primitive: consistent help (`3.2.6`),
+redundant entry (`3.3.7`), and accessible authentication (`3.3.8`).
+
+## Tests
+
+- web-react keeps shared accessibility tests under `packages/web-react/tests/accessibilityTests/` and
+  per-component `packages/web-react/src/components/<Component>/__tests__/*.accessibility.test.tsx`. A
+  new or changed interactive component without an accessibility test is a `todo`.
+- web has SCSS a11y tooling under `packages/web/src/scss/tools/_accessibility.scss`.
+
+## References
+
+- `references/accessibility-checklist.md` — the detailed, actionable checklist (keyboard, screen
+  readers, visual, forms, content, ARIA live regions, common anti-patterns, impact prioritization,
+  and automated-testing commands). The `accessibility-reviewer` applies it.
+- `references/accessibility-patterns.md` — worked, Spirit-adapted code patterns (icon-button names,
+  `:focus-visible` with the `focus-ring` token, error fields, live regions, modal focus management,
+  form labels, reduced motion, and the new 2.2 patterns).

--- a/.agents/skills/accessibility/SKILL.md
+++ b/.agents/skills/accessibility/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: spirit:accessibility
+description: >-
+  Audit and improve web accessibility, semantics, ARIA, keyboard
+  operability, focus management, contrast, following WCAG 2.2 guidelines. Always apply when adding or reviewing Spirit components and features. Also triggered by "improve accessibility", "a11y audit", "WCAG compliance", "screen reader support", "keyboard navigation", or "make accessible".
+---
+
+# Accessibility
+
+Accessibility is a primary review lens for Spirit — design-system components are consumed everywhere,
+so an a11y regression multiplies. Target **WCAG 2.2 AA**. Spans React (`.tsx`), vanilla HTML, and
+SCSS.
+
+A **blocking** finding is appropriate when a change removes or breaks accessibility that previously
+worked (keyboard trap, lost focus, missing accessible name on an interactive control).
+
+## Beyond the Component
+
+A few WCAG 2.2-only success criteria are **application-level** and rarely actionable on an isolated
+component — note them for consumers but don't force them onto a primitive: consistent help (`3.2.6`),
+redundant entry (`3.3.7`), and accessible authentication (`3.3.8`).
+
+## References
+
+- `references/accessibility-checklist.md` — the detailed, actionable checklist (keyboard, screen
+  readers, visual, forms, content, ARIA live regions, common anti-patterns, impact prioritization,
+  and automated-testing commands).
+- `references/accessibility-patterns.md` — worked, Spirit-adapted code patterns (icon-button names,
+  `:focus-visible` with the `focus-ring` token, error fields, live regions, modal focus management,
+  form labels, reduced motion, and the new 2.2 patterns).

--- a/.agents/skills/accessibility/references/accessibility-checklist.md
+++ b/.agents/skills/accessibility/references/accessibility-checklist.md
@@ -1,0 +1,128 @@
+# Accessibility Checklist
+
+The actionable accessibility checklist. Target **WCAG 2.2 AA**.
+Because these are design-system components, an a11y defect ships to every consumer —
+treat a regression of previously-working accessibility as **blocking**. Intentional exceptions
+should be documented with a comment explaining the trade-off. Findings use the format in
+the code-review methodology. Worked code examples for these items live in `accessibility-patterns.md`.
+
+## Keyboard Navigation
+
+- Every interactive element is reachable and operable by keyboard (Tab to reach, Enter/Space to
+  activate, Escape to dismiss overlays where expected).
+- Tab order follows visual order.
+- Every focusable element has a **visible focus indicator** — use the design system's `focus-ring`
+  token and prefer `:focus-visible` over `:focus` for pointer interactions.
+- Custom widgets (menu, combobox, tabs, dialog, disclosure) implement the expected keyboard pattern
+  for their role.
+- No keyboard traps.
+- Focus moves into a dialog/overlay on open and returns to the trigger on close; focus is trapped
+  within a modal surface while it is open.
+- A focused element is not fully hidden by sticky headers/footers or overlapping panels (`2.4.11`)
+  — reserve space with `scroll-margin`.
+
+## Screen Readers
+
+- Every interactive control has an **accessible name** (visible label, `aria-label`, or
+  `aria-labelledby`).
+- Icon-only controls have a text alternative; decorative icons are hidden (`aria-hidden` / empty `alt`).
+- Images have meaningful `alt`, or empty `alt` when decorative.
+- Form controls are programmatically associated with their labels.
+- Heading levels are logical and do not skip.
+- Dynamic updates that must be announced use an appropriate live region (see [ARIA Live Regions](#aria-live-regions)).
+- Data tables use proper markup (`th`, `scope`).
+- Screen-reader-only text uses a visually-hidden utility (`VisuallyHidden` in React,
+  `.accessibility-hidden` in vanilla CSS), not `display: none` (which removes it from the
+  accessibility tree).
+
+## Visual
+
+- Text and meaningful UI meet WCAG AA contrast (`1.4.3`, `1.4.11`) — rely on the design tokens, which
+  are designed to pass.
+
+  | Element                                | AA minimum | AAA enhanced |
+  | -------------------------------------- | ---------- | ------------ |
+  | Normal text (< 18px / < 14px bold)     | 4.5:1      | 7:1          |
+  | Large text (≥ 18px / ≥ 14px bold)      | 3:1        | 4.5:1        |
+  | UI components & graphics (incl. focus) | 3:1        | 3:1          |
+
+- State and meaning are **never conveyed by color alone** (`1.4.1`).
+- The component remains usable at 200% zoom / increased text size — no clipping or overlap.
+- Animation and transition respects `prefers-reduced-motion`.
+- Focus and state styles stay visible across all themes.
+
+## Forms
+
+- Every field has a visible, persistent `<label>` — placeholder text is not a label.
+- Required fields are indicated non-visually too, not by color or an asterisk alone.
+- Errors are associated programmatically (`aria-describedby`) and announced; never conveyed by color
+  alone.
+- Group related controls with `fieldset`/`legend`.
+- Use an appropriate input `type` and `autocomplete`.
+- On submit, errors are surfaced and focus moves to the first error or an error summary.
+
+## Content
+
+- Interactive targets are at least 24×24 CSS px (`2.5.8`), unless an inline text link,
+  browser-sized, or spaced so a 24px circle on each does not overlap a neighbour. Aim for 44×44 on
+  primary actions.
+- Any dragging interaction has a single-pointer alternative (`2.5.7`).
+- Links are distinguishable from surrounding text by more than color.
+- Empty and loading states are conveyed to assistive technology.
+
+## ARIA Live Regions
+
+| Need                                | Politeness | Role / attribute                          |
+| ----------------------------------- | ---------- | ----------------------------------------- |
+| Status, progress, non-urgent update | polite     | `role="status"` or `aria-live="polite"`   |
+| Error or time-sensitive alert       | assertive  | `role="alert"` or `aria-live="assertive"` |
+
+Use live regions sparingly — overuse makes a screen reader noisy. The region must exist in the DOM
+before its content changes.
+
+## Common Anti-Patterns
+
+- `div`/`span` with an `onClick` acting as a button → use `<button>`, unless an appropriate `role`
+  is present (e.g. `role="option"`, `role="menuitem"`).
+- Icon button with no name → add `aria-label` or visually-hidden text.
+- State shown by color only → add text, an icon, or an ARIA state.
+- Positive `tabindex` → avoid; rely on DOM order with `tabindex="0"`/`"-1"` only.
+- Removing the focus outline without a replacement → use the `focus-ring` token.
+- `aria-label` that contradicts the visible label → keep them consistent.
+- Redundant role names in `aria-label` (e.g. `aria-label="Primary navigation"` on `<nav>` is
+  announced as "Primary navigation, navigation") → omit the element type/role from the label.
+- `display: none` for screen-reader-only text → use a visually-hidden utility.
+- Redundant ARIA (e.g. `role="button"` on a `<button>`) → remove it; native semantics win.
+
+## Prioritizing Findings
+
+Map severity to the repo's review framing so triage is consistent:
+
+- **Critical** (→ usually **blocking**): missing form label, missing image `alt`, insufficient
+  contrast, keyboard trap, no visible focus indicator.
+- **Serious** (→ blocking or strong `todo`): missing page `lang`, broken heading structure,
+  non-descriptive link text, auto-playing media, missing skip link.
+- **Moderate** (→ `todo`/suggestion): missing icon labels, inconsistent navigation, weak error
+  identification, uncontrolled timing, missing landmark regions.
+
+## Testing
+
+web-react keeps shared accessibility tests under `packages/web-react/tests/accessibilityTests/` and
+per-component `packages/web-react/src/components/<Component>/__tests__/*.accessibility.test.tsx`; web
+has SCSS a11y tooling under `packages/web/src/scss/tools/_accessibility.scss`. A new or changed
+interactive component without an accessibility test is a `todo`.
+
+These complement — they do not replace — `eslint-plugin-jsx-a11y` (static) and manual checks. For a
+quick automated pass against a running page or Storybook story:
+
+```bash
+# Lighthouse accessibility category only
+npx lighthouse <url> --only-categories=accessibility
+
+# axe-core CLI
+npx @axe-core/cli <url>
+```
+
+Automated tools catch only a fraction of issues. Complement them with manual checks: Tab through
+the whole flow, test with a screen reader (VoiceOver / NVDA), check 200% zoom, and exercise
+`prefers-reduced-motion`.

--- a/.agents/skills/accessibility/references/accessibility-checklist.md
+++ b/.agents/skills/accessibility/references/accessibility-checklist.md
@@ -1,0 +1,128 @@
+# Accessibility Checklist
+
+The actionable accessibility checklist. Target **WCAG 2.2 AA**.
+Because these are design-system components, an a11y defect ships to every consumer —
+treat a regression of previously-working accessibility as **blocking**. Intentional exceptions
+should be documented with a comment explaining the trade-off. Findings use the format in
+the code-review methodology. Worked code examples for these items live in `accessibility-patterns.md`.
+
+## Keyboard Navigation
+
+- Every interactive element is reachable and operable by keyboard (Tab to reach, Enter/Space to
+  activate, Escape to dismiss overlays where expected).
+- Tab order follows visual order.
+- Every focusable element has a **visible focus indicator** — use the design system's `focus-ring`
+  token and prefer `:focus-visible` over `:focus` for pointer interactions.
+- Custom widgets (menu, combobox, tabs, dialog, disclosure) implement the expected keyboard pattern
+  for their role.
+- No keyboard traps.
+- Focus moves into a dialog/overlay on open and returns to the trigger on close; focus is trapped
+  within a modal surface while it is open.
+- A focused element is not fully hidden by sticky headers/footers or overlapping panels (`2.4.11`)
+  — reserve space with `scroll-margin`.
+
+## Screen Readers
+
+- Every interactive control has an **accessible name** (visible label, `aria-label`, or
+  `aria-labelledby`).
+- Icon-only controls have a text alternative; decorative icons are hidden (`aria-hidden` / empty `alt`).
+- Images have meaningful `alt`, or empty `alt` when decorative.
+- Form controls are programmatically associated with their labels.
+- Heading levels are logical and do not skip.
+- Dynamic updates that must be announced use an appropriate live region (see [ARIA Live Regions](#aria-live-regions)).
+- Data tables use proper markup (`th`, `scope`).
+- Screen-reader-only text uses a visually-hidden utility (`VisuallyHidden` in React,
+  `.accessibility-hidden` in vanilla CSS), not `display: none` (which removes it from the
+  accessibility tree).
+
+## Visual
+
+- Text and meaningful UI meet WCAG AA contrast (`1.4.3`, `1.4.11`) — rely on the design tokens, which
+  are designed to pass.
+
+  | Element                                | AA minimum | AAA enhanced |
+  | -------------------------------------- | ---------- | ------------ |
+  | Normal text (< 18px / < 14px bold)     | 4.5:1      | 7:1          |
+  | Large text (≥ 18px / ≥ 14px bold)      | 3:1        | 4.5:1        |
+  | UI components & graphics (incl. focus) | 3:1        | 3:1          |
+
+- State and meaning are **never conveyed by color alone** (`1.4.1`).
+- The component remains usable at 200% zoom / increased text size — no clipping or overlap.
+- Animation and transition respects `prefers-reduced-motion`.
+- Focus and state styles stay visible across all themes.
+
+## Forms
+
+- Every field has a programmatically associated `<label>` — visible is preferred; visually-hidden is
+  acceptable when context makes the purpose unambiguous. Placeholder text is not a label.
+- Required fields are indicated non-visually too, not by color or an asterisk alone.
+- Errors are associated programmatically (`aria-describedby`) and announced; never conveyed by color
+  alone.
+- Group related controls with `fieldset`/`legend`.
+- Use an appropriate input `type` and `autocomplete`.
+- On submit, errors are surfaced and focus moves to the first error or an error summary.
+
+## Content
+
+- Interactive targets are at least 24×24 px (`2.5.8`), unless an inline text link,
+  browser-sized, or spaced so a 24px circle on each does not overlap a neighbour. Aim for 44×44 on
+  primary actions.
+- Any dragging interaction has a single-pointer alternative (`2.5.7`).
+- Links are distinguishable from surrounding text by more than color.
+- Empty and loading states are conveyed to assistive technology.
+
+## ARIA Live Regions
+
+| Need                                | Politeness | Role / attribute                          |
+| ----------------------------------- | ---------- | ----------------------------------------- |
+| Status, progress, non-urgent update | polite     | `role="status"` or `aria-live="polite"`   |
+| Error or time-sensitive alert       | assertive  | `role="alert"` or `aria-live="assertive"` |
+
+Use live regions sparingly — overuse makes a screen reader noisy. The region must exist in the DOM
+before its content changes.
+
+## Common Anti-Patterns
+
+- `div`/`span` with an `onClick` acting as a button → use `<button>`, unless an appropriate `role`
+  is present (e.g. `role="option"`, `role="menuitem"`).
+- Icon button with no name → add `aria-label` or visually-hidden text.
+- State shown by color only → add text, an icon, or an ARIA state.
+- Positive `tabindex` → avoid; rely on DOM order with `tabindex="0"`/`"-1"` only.
+- Removing the focus outline without a replacement → use the `focus-ring` token.
+- `aria-label` that contradicts the visible label → keep them consistent.
+- Redundant role names in `aria-label` (e.g. `aria-label="Primary navigation"` on `<nav>` is
+  announced as "Primary navigation, navigation") → omit the element type/role from the label.
+- `display: none` for screen-reader-only text → use a visually-hidden utility.
+- Redundant ARIA (e.g. `role="button"` on a `<button>`) → remove it; native semantics win.
+
+## Prioritizing Findings
+
+Map severity to the repo's review framing so triage is consistent:
+
+- **Critical** (→ usually **blocking**): missing form label, missing image `alt`, insufficient
+  contrast, keyboard trap, no visible focus indicator.
+- **Serious** (→ blocking or strong `todo`): missing page `lang`, broken heading structure,
+  non-descriptive link text, auto-playing media, missing skip link.
+- **Moderate** (→ `todo`/suggestion): missing icon labels, inconsistent navigation, weak error
+  identification, uncontrolled timing, missing landmark regions.
+
+## Testing
+
+The `web-react` package keeps shared accessibility tests under `packages/web-react/tests/accessibilityTests/` and
+per-component `packages/web-react/src/components/<Component>/__tests__/*.accessibility.test.tsx`. A new or changed
+interactive component without an accessibility test is a `todo`.
+
+These complement — they do not replace — `eslint-plugin-jsx-a11y` (static) and manual checks. For a
+quick automated pass against a running page or Storybook story:
+
+```bash
+# Lighthouse accessibility category only
+yarn dlx lighthouse <url> --only-categories=accessibility
+
+# axe-core CLI
+yarn dlx @axe-core/cli <url>
+```
+
+Automated tools catch only a fraction of issues. Complement them with manual checks: Tab through
+the whole flow, test with a screen reader (VoiceOver / NVDA), check 200% zoom, and exercise
+`prefers-reduced-motion`.

--- a/.agents/skills/accessibility/references/accessibility-patterns.md
+++ b/.agents/skills/accessibility/references/accessibility-patterns.md
@@ -1,0 +1,228 @@
+# Accessibility Code Patterns
+
+Worked, copy-ready accessibility patterns for Spirit, used alongside `accessibility-checklist.md`.
+Every example uses Spirit primitives — the `VisuallyHidden` component, the `$focus-ring` token, and
+the SCSS a11y tools (`hide-text()`, `min-tap-target()`) — rather than ad-hoc CSS. Target **WCAG 2.2
+AA**.
+
+## Accessible Name for Icon-Only Controls (1.1.1, 4.1.2)
+
+Prefer hidden label text over `aria-label` — hidden text is translatable by browser translators,
+while `aria-label` is not. This is the pattern used by Spirit's own close buttons
+(`DrawerCloseButton`, `TooltipCloseButton`).
+
+### React (TSX)
+
+```tsx
+import { VisuallyHidden } from '../VisuallyHidden';
+
+// ✅ Preferred: icon + hidden label text (translatable)
+<button type="button" onClick={onClose}>
+  <Icon name="close" />
+  <VisuallyHidden>Close dialog</VisuallyHidden>
+</button>
+
+// ✅ Alternative: aria-label (browser translators may not translate this for screen reader users)
+<button type="button" aria-label="Close dialog" onClick={onClose}>
+  <Icon name="close" />
+</button>
+```
+
+### Vanilla HTML
+
+```html
+<!-- ✅ Preferred: icon + .accessibility-hidden span -->
+<button type="button">
+  <!-- icon SVG or img here -->
+  <span class="accessibility-hidden">Close dialog</span>
+</button>
+
+<!-- ✅ Alternative: aria-label -->
+<button type="button" aria-label="Close dialog">
+  <!-- icon SVG or img here -->
+</button>
+```
+
+### Vanilla HTML + custom SCSS
+
+Use when you need a custom selector instead of the `.accessibility-hidden` helper class.
+
+```html
+<button type="button">
+  <!-- icon SVG or img here -->
+  <span class="MyButton__label">Close dialog</span>
+</button>
+```
+
+```scss
+@use '../../tools/accessibility';
+
+.MyButton__label {
+  @include accessibility.hide-text();
+}
+```
+
+Avoid: `aria-label` that contradicts the visible text, or `display: none` for SR-only content (it is
+removed from the accessibility tree).
+
+## Don't Rely on Color Alone (1.4.1, 3.3.1)
+
+State and errors need a non-color signal — text and/or an icon — plus the programmatic association.
+
+```html
+<div>
+  <label for="email">Email</label>
+  <input id="email" type="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error" role="alert">
+    <!-- icon or symbol here — non-color signal -->
+    Enter a valid email address.
+  </p>
+</div>
+```
+
+## Visible Focus with the Design-System Token (2.4.7, 1.4.11)
+
+Never drop the focus outline without an equivalent. Use the `$focus-ring` token; prefer
+`:focus-visible` so the ring shows for keyboard users without flashing on pointer clicks. The token
+is contrast-checked to meet the 3:1 UI-component minimum.
+
+```scss
+@use '@tokens' as tokens;
+
+.MyControl:focus-visible {
+  outline: none;
+  box-shadow: tokens.$focus-ring;
+}
+```
+
+## Focus Not Obscured by Sticky Chrome (2.4.11)
+
+A focused element must not be fully hidden behind a sticky header/footer. Reserve room with
+`scroll-margin` so it scrolls into the clear.
+
+```scss
+@use '@tokens' as tokens;
+
+:focus-visible {
+  scroll-margin-top: var(--#{tokens.$css-variable-prefix}sticky-header-height, 5rem);
+  scroll-margin-bottom: tokens.$space-700;
+}
+```
+
+## Target Size (2.5.8)
+
+Interactive targets are ≥ 24×24 CSS px. When the visible control is smaller (e.g. a compact icon
+button), expand the hit area without changing the layout using the `min-tap-target()` mixin or the
+`.accessibility-tap-target` helper.
+
+```scss
+@use '../../tools/accessibility';
+
+.MyIconButton {
+  @include accessibility.min-tap-target(24px); // adds a centered ::before hit area
+}
+```
+
+## Dragging Movements Need a Pointer Alternative (2.5.7)
+
+Any reorder/slider/drag interaction must also be operable with discrete controls.
+
+```tsx
+// ✅ Drag to reorder, AND up/down buttons that do the same thing
+<li>
+  <span>{item.label}</span>
+  <button type="button" aria-label={`Move ${item.label} up`} onClick={() => move(item.id, -1)}>
+    ↑
+  </button>
+  <button type="button" aria-label={`Move ${item.label} down`} onClick={() => move(item.id, 1)}>
+    ↓
+  </button>
+</li>
+```
+
+## Form Labels (3.3.2)
+
+Every field has a programmatically associated, visible label. Placeholder text is not a label. Group
+related controls with `fieldset`/`legend`.
+
+```tsx
+// ✅ Explicit association
+<label htmlFor="first-name">First name</label>
+<input id="first-name" name="firstName" type="text" autoComplete="given-name" />
+
+// ✅ Grouping
+<fieldset>
+  <legend>Contact preference</legend>
+  <label><input type="radio" name="contact" value="email" /> Email</label>
+  <label><input type="radio" name="contact" value="phone" /> Phone</label>
+</fieldset>
+```
+
+## Error Handling on Submit (3.3.1, 3.3.3)
+
+Announce errors, mark invalid fields, and move focus to the first error (or an error summary).
+
+```tsx
+function handleSubmit(event) {
+  event.preventDefault();
+  const errors = validate(form);
+  if (errors.length > 0) {
+    setErrors(errors);
+    // Move focus to the first invalid field so the error is announced
+    document.getElementById(errors[0].fieldId)?.focus();
+  }
+}
+```
+
+## Live Regions (4.1.3)
+
+Announce dynamic updates without moving focus. The region must already exist in the DOM before its
+content changes. Use them sparingly.
+
+| Need                                | Politeness | Role / attribute                          |
+| ----------------------------------- | ---------- | ----------------------------------------- |
+| Status, progress, non-urgent update | polite     | `role="status"` or `aria-live="polite"`   |
+| Error or time-sensitive alert       | assertive  | `role="alert"` or `aria-live="assertive"` |
+
+```tsx
+// Persistent region, content updated later
+<div role="status" aria-live="polite" className="MyComponent__status">
+  {statusMessage}
+</div>
+```
+
+## Modal Focus Management
+
+Prefer the native `<dialog>` element — it traps focus and handles `Escape` automatically. When you
+build a custom overlay, move focus in on open, trap it while open, and restore it to the trigger on
+close.
+
+```tsx
+const triggerRef = useRef(null);
+const dialogRef = useRef(null);
+
+function open() {
+  triggerRef.current = document.activeElement; // remember the trigger
+  dialogRef.current?.showModal(); // native focus trap + Escape
+}
+
+function close() {
+  dialogRef.current?.close();
+  triggerRef.current?.focus(); // restore focus
+}
+```
+
+## Reduced Motion (2.3.3)
+
+Respect the user's preference; wrap animations in the `no-preference` query so they are off by
+default for users who have requested reduced motion.
+
+```scss
+@use 'theme';
+
+@media (prefers-reduced-motion: no-preference) {
+  .MyComponent {
+    transition: background theme.$transition-duration theme.$transition-timing;
+  }
+}
+```

--- a/.agents/skills/accessibility/references/accessibility-patterns.md
+++ b/.agents/skills/accessibility/references/accessibility-patterns.md
@@ -1,0 +1,254 @@
+# Accessibility Code Patterns
+
+Worked, copy-ready accessibility patterns for Spirit, used alongside `accessibility-checklist.md`.
+Every example uses Spirit primitives — the `VisuallyHidden` component, the `$focus-ring` token, and
+the SCSS a11y tools (`hide-text()`, `min-tap-target()`) — rather than ad-hoc CSS. Target **WCAG 2.2
+AA**.
+
+## Accessible Name for Icon-Only Controls (1.1.1, 4.1.2)
+
+Prefer hidden label text over `aria-label` — hidden text is translatable by browser translators,
+while `aria-label` is not. This is the pattern used by Spirit's own `CloseButton` component.
+
+### React (TSX)
+
+```tsx
+import { VisuallyHidden } from '../VisuallyHidden';
+
+// ✅ Preferred: icon + hidden label text (translatable)
+<button type="button" onClick={onClose}>
+  <Icon name="close" />
+  <VisuallyHidden>Close dialog</VisuallyHidden>
+</button>
+
+// ✅ Alternative: aria-label (browser translators may not translate this for screen reader users)
+<button type="button" aria-label="Close dialog" onClick={onClose}>
+  <Icon name="close" />
+</button>
+```
+
+### Vanilla HTML
+
+```html
+<!-- ✅ Preferred: icon + .accessibility-hidden span -->
+<button type="button">
+  <!-- icon SVG or img here -->
+  <span class="accessibility-hidden">Close dialog</span>
+</button>
+
+<!-- ✅ Alternative: aria-label -->
+<button type="button" aria-label="Close dialog">
+  <!-- icon SVG or img here -->
+</button>
+```
+
+### Vanilla HTML + Custom SCSS
+
+Use when you need a custom selector instead of the `.accessibility-hidden` helper class.
+
+```html
+<button type="button" class="MyButton">
+  <!-- icon SVG or img here -->
+  <span class="MyButton__label">Close dialog</span>
+</button>
+```
+
+```scss
+@use '../../tools/accessibility';
+
+.MyButton__label {
+  @include accessibility.hide-text();
+}
+```
+
+Avoid: `aria-label` that contradicts the visible text, or `display: none` for SR-only content (it is
+removed from the accessibility tree).
+
+## Don't Rely on Color Alone (1.4.1, 3.3.1)
+
+State and errors need a non-color signal — text and/or an icon — plus the programmatic association.
+
+```html
+<div>
+  <label for="email">Email</label>
+  <input id="email" type="email" aria-invalid="true" aria-describedby="email-error" />
+  <p id="email-error" role="alert">
+    <!-- icon or symbol here — non-color signal -->
+    Enter a valid email address.
+  </p>
+</div>
+```
+
+## Visible Focus with the Design-System Token (2.4.7, 1.4.11)
+
+Never drop the focus outline without an equivalent. Use the `$focus-ring` token; prefer
+`:focus-visible` so the ring shows for keyboard users without flashing on pointer clicks. The token
+is contrast-checked to meet the 3:1 UI-component minimum.
+
+```scss
+@use '@tokens' as tokens;
+
+.MyControl:focus-visible {
+  outline: none;
+  box-shadow: tokens.$focus-ring;
+}
+```
+
+## Focus Not Obscured by Sticky Headers/Footers (2.4.11)
+
+A focused element must not be fully hidden behind a sticky header/footer. Reserve room with
+`scroll-margin` so it scrolls into the clear.
+
+```scss
+@use '@tokens' as tokens;
+
+// Scope to a scrollable wrapper rather than using a global selector — apply where needed.
+.MyScrollableContainer :focus-visible {
+  scroll-margin-top: var(--#{tokens.$css-variable-prefix}sticky-header-height, 5rem);
+  scroll-margin-bottom: tokens.$space-700;
+}
+```
+
+## Target Size (2.5.8)
+
+Interactive targets are ≥ 24×24 px. When the visible control is smaller (e.g. a compact icon
+button or any element with a small visual footprint), expand the hit area without changing the layout
+using a11y utility mixins or helper classes — for example `min-tap-target()` or
+`.accessibility-tap-target` (see `packages/web/src/scss/tools/_accessibility.scss` for the current
+set of available utilities).
+
+```scss
+@use '../../tools/accessibility';
+
+.MyIconButton {
+  @include accessibility.min-tap-target(24px); // adds a centered ::before hit area
+}
+```
+
+When a link should cover an entire container (e.g. a card) rather than just a fixed hit zone, use
+`pseudo-element.stretch()` or the `.element-stretched` helper class instead. The nearest
+`position: relative` ancestor becomes the clickable boundary.
+
+```scss
+@use '../../tools/pseudo-element';
+
+.MyCard {
+  position: relative;
+}
+
+.MyCard__link {
+  @include pseudo-element.stretch(); // ::before stretches to inset: 0 of the parent
+}
+```
+
+Or with the helper class:
+
+```html
+<div class="MyCard" style="position: relative;">
+  <a href="#" class="MyCard__link element-stretched">Card title</a>
+</div>
+```
+
+## Dragging Movements Need a Pointer Alternative (2.5.7)
+
+Any reorder/slider/drag interaction must also be operable with discrete controls.
+
+```tsx
+// ✅ Drag to reorder, AND up/down buttons that do the same thing
+<li>
+  <span>{item.label}</span>
+  <button type="button" aria-label={`Move ${item.label} up`} onClick={() => move(item.id, -1)}>
+    ↑
+  </button>
+  <button type="button" aria-label={`Move ${item.label} down`} onClick={() => move(item.id, 1)}>
+    ↓
+  </button>
+</li>
+```
+
+## Form Labels (3.3.2)
+
+Every field has a programmatically associated label. Placeholder text is not a label. Group
+related controls with `fieldset`/`legend`.
+
+```tsx
+// ✅ Explicit association
+<label htmlFor="first-name">First name</label>
+<input id="first-name" name="firstName" type="text" autoComplete="given-name" />
+
+// ✅ Grouping
+<fieldset>
+  <legend>Contact preference</legend>
+  <label><input type="radio" name="contact" value="email" /> Email</label>
+  <label><input type="radio" name="contact" value="phone" /> Phone</label>
+</fieldset>
+```
+
+## Error Handling on Submit (3.3.1, 3.3.3)
+
+Announce errors, mark invalid fields, and move focus to the first error (or an error summary).
+
+```tsx
+function handleSubmit(event) {
+  event.preventDefault();
+  const errors = validate(form);
+  if (errors.length > 0) {
+    setErrors(errors);
+    // Move focus to the first invalid field so the error is announced
+    document.getElementById(errors[0].fieldId)?.focus();
+  }
+}
+```
+
+## Live Regions (4.1.3)
+
+Announce dynamic updates without moving focus. The region must already exist in the DOM before its
+content changes. Use them sparingly.
+
+| Need                                | Politeness | Role / attribute                          |
+| ----------------------------------- | ---------- | ----------------------------------------- |
+| Status, progress, non-urgent update | polite     | `role="status"` or `aria-live="polite"`   |
+| Error or time-sensitive alert       | assertive  | `role="alert"` or `aria-live="assertive"` |
+
+```tsx
+// Persistent region, content updated later
+<div role="status" aria-live="polite" className="MyComponent__status">
+  {statusMessage}
+</div>
+```
+
+## Modal Focus Management
+
+Prefer the native `<dialog>` element — it traps focus and handles `Escape` automatically. When you
+build a custom overlay, move focus in on open, trap it while open, and restore it to the trigger on
+close.
+
+```tsx
+const triggerRef = useRef(null);
+const dialogRef = useRef(null);
+
+function open() {
+  triggerRef.current = document.activeElement; // remember the trigger
+  dialogRef.current?.showModal(); // native focus trap + Escape
+}
+
+function close() {
+  dialogRef.current?.close();
+  triggerRef.current?.focus(); // restore focus
+}
+```
+
+## Reduced Motion (2.3.3)
+
+Respect the user's preference; wrap animations in the `no-preference` query so they are off by
+default for users who have requested reduced motion.
+
+```scss
+@use 'theme';
+
+@media (prefers-reduced-motion: no-preference) {
+  .MyComponent {
+    transition: background theme.$transition-duration theme.$transition-timing;
+  }
+}
+```

--- a/.agents/skills/accessibility/references/accessibility-patterns.md
+++ b/.agents/skills/accessibility/references/accessibility-patterns.md
@@ -43,7 +43,7 @@ import { VisuallyHidden } from '../VisuallyHidden';
 </button>
 ```
 
-### Vanilla HTML + custom SCSS
+### Vanilla HTML + Custom SCSS
 
 Use when you need a custom selector instead of the `.accessibility-hidden` helper class.
 


### PR DESCRIPTION
## Description

Part of splitting the agentic code-review rework (umbrella: #2581) into one reviewable skill per PR.

Introduces the `accessibility` knowledge skill — a first-class a11y lens (semantics-first, keyboard/focus, forms, visual/motion) with an actionable accessibility checklist reference. Standalone-runnable, loaded by the code-review reviewers via `cat`.

### Additional context

Draft, part of a series split out of #2581. The skills are interdependent; see #2581 for the full picture and the sibling per-skill PRs.

- https://github.com/addyosmani/web-quality-skills/blob/main/skills/accessibility/SKILL.md
- https://github.com/addyosmani/agent-skills/blob/main/references/accessibility-checklist.md
