### PR TITLE
feat(web-react): introduce Collection pattern for `UNSTABLE_Picker` and `UNSTABLE_Combobox`

### DIFF
--- a/docs/content/collections.md
+++ b/docs/content/collections.md
@@ -1,0 +1,50 @@
+# Collection Pattern
+
+Collections provide a stable tree of item and section nodes built from React children — without reading the live DOM. They are the shared foundation for item identity, labels, hierarchy, and disabled state in components such as [UNSTABLE_Picker][picker] and [UNSTABLE_Combobox][combobox].
+
+## Overview
+
+Many Spirit components render a list of selectable or navigable items composed as JSX children. Walking those children ad hoc (and falling back to DOM queries for labels) duplicates fragile logic across components.
+
+A **Collection** walks the element tree once and produces a stable node tree for identity, labels, hierarchy, and disabled state. Selection, keyboard behavior, and consumer-owned filtering stay in separate layers (`useSelectionState`, grid keyboard hooks, Combobox `inputValue` filtering).
+
+## When to Use
+
+- Building or extending a component that needs option/item identity from JSX children
+- Grouping items (sections) that should exist in the data model, not only visually
+- Deriving labels for tags / aria without querying the DOM
+- Preparing a filtered _view_ of items for navigation helpers
+
+## When Not to Use
+
+- Do not use Collection as a replacement for Selection state
+- Do not put consumer filtering inside Collection for Combobox today — Combobox filtering remains owned by the consumer (unmount matching options + `optionKeys`)
+- Do not introduce a public `items` prop on Picker/Combobox solely because the builder supports a dynamic path
+
+## Best Practices
+
+### Declare Identity on Item / Section Components
+
+Item and section components should declare how they appear in the collection (key, label text, optional disabled state). If you wrap an item in `memo` / HOC, forward that declaration (same class of issue as forwarding `spiritComponent`).
+
+See [`hooks/collection`][collection-hooks] for the API and examples.
+
+### Prefer Flat Item Iteration for Selection UIs
+
+Sections may exist in the tree (e.g. `UNSTABLE_PickerGroup`), but tag/selection UIs usually iterate flat item nodes so behavior stays a flat list of values.
+
+### Keep Filtering Ownership Clear
+
+- Library helpers can produce a filtered Collection view (tests / future consumers).
+- **Combobox** — consumer filters data and mounts matching `UNSTABLE_ComboboxOption` children; pass `optionKeys` when selected options can unmount.
+
+## Related Hooks and Components
+
+- [`hooks/collection`][collection-hooks] — API for `useCollection`, `createCollection`, `filterCollection`, `getNodeText`
+- [`useSelectionState`][selection] — selection keys
+- [UNSTABLE_Picker][picker] / [UNSTABLE_Combobox][combobox]
+
+[collection-hooks]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/hooks/collection/README.md
+[combobox]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_Combobox/README.md
+[picker]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/components/UNSTABLE_Picker/README.md
+[selection]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web-react/src/hooks/useSelectionState.ts

--- a/packages/web-react/src/components/UNSTABLE_Combobox/ComboboxBase.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/ComboboxBase.tsx
@@ -125,7 +125,7 @@ const ComboboxBase = (props: ComboboxBaseProps) => {
   const selectionGridRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
 
-  const { getOptionRowEl, resolvedOptionKeys, selectedItems, warmItemLabel } = useComboboxItems({
+  const { getOptionRowEl, getVisibleOptionRows, resolvedOptionKeys, selectedItems, warmItemLabel } = useComboboxItems({
     children,
     listboxRef,
     optionKeys,
@@ -168,6 +168,7 @@ const ComboboxBase = (props: ComboboxBaseProps) => {
     close,
     focusInput,
     getOptionRowEl,
+    getVisibleOptionRows,
     inputRef,
     isDisabled,
     isOpen,

--- a/packages/web-react/src/components/UNSTABLE_Combobox/UNSTABLE_ComboboxOption.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/UNSTABLE_ComboboxOption.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import classNames from 'classnames';
-import React from 'react';
+import React, { type ReactNode } from 'react';
+import { getNodeText } from '../../hooks';
 import { Item } from '../Item';
 import { useComboboxPopoverContext } from './ComboboxPopoverContext';
 import type { SpiritUnstableComboboxOptionProps } from './types';
@@ -56,5 +57,17 @@ const UNSTABLE_ComboboxOption = ({
 
 UNSTABLE_ComboboxOption.spiritComponent = 'UNSTABLE_ComboboxOption';
 UNSTABLE_ComboboxOption.displayName = 'UNSTABLE_ComboboxOption';
+
+UNSTABLE_ComboboxOption.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  const children = props.children as ReactNode;
+  const { label } = props;
+
+  yield {
+    type: 'item' as const,
+    key: String(props.value ?? ''),
+    textValue: label != null ? String(label) : getNodeText(children),
+    isDisabled: Boolean(props.isDisabled),
+  };
+};
 
 export default UNSTABLE_ComboboxOption;

--- a/packages/web-react/src/components/UNSTABLE_Combobox/__tests__/utils.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/__tests__/utils.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import { createCollection } from '../../../hooks';
 import { COMBOBOX_OPTION_LABEL_ATTR, COMBOBOX_OPTION_VALUE_ATTR } from '../constants';
 import UNSTABLE_ComboboxOption from '../UNSTABLE_ComboboxOption';
 import {
   areAllOptionsSelected,
-  collectComboboxItems,
   createSelectedKeysSet,
   getComboboxOptionDomId,
   getOptionRowCellControls,
@@ -101,19 +101,27 @@ describe('UNSTABLE_Combobox utils', () => {
     expect(getOptionRowCellControls(row)).toEqual([button]);
   });
 
-  it('collectComboboxItems should collect key, label, and disabled metadata', () => {
-    const items = collectComboboxItems(
-      <>
-        <UNSTABLE_ComboboxOption value="cs" label="Czech short">
-          Czech Republic
-        </UNSTABLE_ComboboxOption>
-        <UNSTABLE_ComboboxOption value="en" isDisabled>
-          English
-        </UNSTABLE_ComboboxOption>
-      </>,
-    );
+  it('collection should collect key, label, and disabled metadata from options', () => {
+    const collection = createCollection({
+      children: (
+        <>
+          <UNSTABLE_ComboboxOption value="cs" label="Czech short">
+            Czech Republic
+          </UNSTABLE_ComboboxOption>
+          <UNSTABLE_ComboboxOption value="en" isDisabled>
+            English
+          </UNSTABLE_ComboboxOption>
+        </>
+      ),
+    });
 
-    expect(items).toEqual([
+    expect(
+      [...collection.getItemNodes()].map((node) => ({
+        key: node.key,
+        label: node.textValue,
+        isDisabled: Boolean(node.isDisabled),
+      })),
+    ).toEqual([
       { key: 'cs', label: 'Czech short', isDisabled: false },
       { key: 'en', label: 'English', isDisabled: true },
     ]);

--- a/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxInteractions.ts
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxInteractions.ts
@@ -3,7 +3,7 @@
 import { type FocusEvent, type KeyboardEvent, type MouseEvent, type RefObject, useCallback } from 'react';
 import { COMBOBOX_OPTION_ITEM_SELECTOR } from './constants';
 import { useComboboxOptionGridKeyboard } from './useComboboxOptionGridKeyboard';
-import { getOptionRowFromFocus, getOptionValueFromRow, getVisibleOptionRows, isOptionRowDisabled } from './utils';
+import { getOptionRowFromFocus, getOptionValueFromRow, isOptionRowDisabled } from './utils';
 
 export interface UseComboboxInteractionsProps {
   activeDescendantId?: string;
@@ -12,6 +12,7 @@ export interface UseComboboxInteractionsProps {
   close: () => void;
   focusInput: () => void;
   getOptionRowEl: (optionId: string) => HTMLElement | null;
+  getVisibleOptionRows: () => HTMLElement[];
   inputRef: RefObject<HTMLInputElement>;
   isDisabled?: boolean;
   isOpen: boolean;
@@ -46,6 +47,7 @@ export interface UseComboboxInteractionsReturn {
  * @param props.close Close the options popover
  * @param props.focusInput Focus the filter input
  * @param props.getOptionRowEl Resolve an option row element by value
+ * @param props.getVisibleOptionRows Mounted option rows from the collection
  * @param props.inputRef Filter input element ref
  * @param props.isDisabled Whether the Combobox is disabled
  * @param props.isOpen Whether the options popover is open
@@ -63,6 +65,7 @@ export const useComboboxInteractions = ({
   close,
   focusInput,
   getOptionRowEl,
+  getVisibleOptionRows,
   inputRef,
   isDisabled = false,
   isOpen,
@@ -93,6 +96,7 @@ export const useComboboxInteractions = ({
     isDisabled,
     activeDescendantId,
     canFocusLastTag,
+    getVisibleOptionRows,
     onOpen: open,
     onClose: close,
     onToggleOption: handleToggleOption,
@@ -124,7 +128,7 @@ export const useComboboxInteractions = ({
 
   // Consumer code may still focus an option (e.g. after removing a row); keep activedescendant in sync.
   const handleListboxFocusCapture = (event: FocusEvent<HTMLElement>) => {
-    const option = getOptionRowFromFocus(event.target, getVisibleOptionRows(listboxRef.current));
+    const option = getOptionRowFromFocus(event.target, getVisibleOptionRows());
 
     if (option?.id) {
       setActiveDescendantId(option.id);

--- a/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxItems.ts
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxItems.ts
@@ -1,14 +1,8 @@
 'use client';
 
-import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
-import { COMBOBOX_OPTION_ITEM_SELECTOR } from './constants';
-import {
-  type ComboboxItem,
-  collectComboboxItems,
-  getOptionRowEl as getOptionRowElFromListbox,
-  getOptionValueFromRow,
-  getRowLabel,
-} from './utils';
+import { type ReactNode, type RefObject, useCallback, useMemo, useRef } from 'react';
+import { useCollection } from '../../hooks';
+import { type ComboboxItem, getOptionRowEl as getOptionRowElFromListbox } from './utils';
 
 export interface ComboboxSelectedItem {
   label: string;
@@ -27,6 +21,8 @@ export interface UseComboboxItemsReturn {
   getItem: (key: string) => ComboboxItem | undefined;
   getItemLabel: (key: string) => string;
   getOptionRowEl: (optionId: string) => HTMLElement | null;
+  /** Mounted option rows resolved from the collection (no DOM visibility scan). */
+  getVisibleOptionRows: () => HTMLElement[];
   itemsByKey: Readonly<Record<string, ComboboxItem>>;
   resolvedOptionKeys: string[];
   selectedItems: ComboboxSelectedItem[];
@@ -52,15 +48,31 @@ export const useComboboxItems = ({
   const labelCacheRef = useRef<Map<string, string>>(new Map());
   const disabledCacheRef = useRef<Map<string, boolean>>(new Map());
 
-  const collectedItems = useMemo(() => collectComboboxItems(children), [children]);
+  const collection = useCollection({ children });
+
+  const collectedItems = useMemo(() => {
+    const items: ComboboxItem[] = [];
+
+    for (const node of collection.getItemNodes()) {
+      const item: ComboboxItem = {
+        key: node.key,
+        label: node.textValue,
+        isDisabled: Boolean(node.isDisabled),
+      };
+
+      items.push(item);
+      labelCacheRef.current.set(item.key, item.label);
+      disabledCacheRef.current.set(item.key, item.isDisabled);
+    }
+
+    return items;
+  }, [collection]);
 
   const itemsByKey = useMemo(() => {
     const map: Record<string, ComboboxItem> = {};
 
     collectedItems.forEach((item) => {
       map[item.key] = item;
-      labelCacheRef.current.set(item.key, item.label);
-      disabledCacheRef.current.set(item.key, item.isDisabled);
     });
 
     return map;
@@ -76,28 +88,19 @@ export const useComboboxItems = ({
     [listboxRef],
   );
 
-  const syncCachesFromDom = useCallback(() => {
-    const listbox = listboxRef.current;
+  const getVisibleOptionRows = useCallback((): HTMLElement[] => {
+    const rows: HTMLElement[] = [];
 
-    if (!listbox) {
-      return;
+    for (const node of collection.getItemNodes()) {
+      const rowEl = getOptionRowEl(node.key);
+
+      if (rowEl) {
+        rows.push(rowEl);
+      }
     }
 
-    listbox.querySelectorAll<HTMLElement>(COMBOBOX_OPTION_ITEM_SELECTOR).forEach((row) => {
-      const optionValue = getOptionValueFromRow(row);
-
-      if (!optionValue) {
-        return;
-      }
-
-      labelCacheRef.current.set(optionValue, getRowLabel(row));
-      disabledCacheRef.current.set(optionValue, row.getAttribute('aria-disabled') === 'true');
-    });
-  }, [listboxRef]);
-
-  useEffect(() => {
-    syncCachesFromDom();
-  }, [children, selectedKeys, syncCachesFromDom]);
+    return rows;
+  }, [collection, getOptionRowEl]);
 
   const getItem = useCallback(
     (key: string): ComboboxItem | undefined => {
@@ -138,20 +141,9 @@ export const useComboboxItems = ({
         return cached;
       }
 
-      const rowEl = getOptionRowEl(key);
-
-      if (rowEl) {
-        const labelText = getRowLabel(rowEl);
-
-        labelCacheRef.current.set(key, labelText);
-        disabledCacheRef.current.set(key, rowEl.getAttribute('aria-disabled') === 'true');
-
-        return labelText;
-      }
-
       return key;
     },
-    [getOptionRowEl, itemsByKey],
+    [itemsByKey],
   );
 
   const warmItemLabel = useCallback(
@@ -170,6 +162,7 @@ export const useComboboxItems = ({
     getItem,
     getItemLabel,
     getOptionRowEl,
+    getVisibleOptionRows,
     itemsByKey,
     resolvedOptionKeys,
     selectedItems,

--- a/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxOptionGridKeyboard.ts
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/useComboboxOptionGridKeyboard.ts
@@ -7,7 +7,7 @@ import {
   mapComboboxInputKeyToAction,
   useIsomorphicLayoutEffect,
 } from '../../hooks';
-import { getOptionRowCellControls, getOptionValueFromRow, getVisibleOptionRows, isOptionRowDisabled } from './utils';
+import { getOptionRowCellControls, getOptionValueFromRow, isOptionRowDisabled } from './utils';
 
 export interface UseComboboxOptionGridKeyboardProps {
   listboxRef: RefObject<HTMLElement | null>;
@@ -17,6 +17,8 @@ export interface UseComboboxOptionGridKeyboardProps {
   activeDescendantId?: string;
   /** When true, Backspace on the empty filter focuses the last selected tag */
   canFocusLastTag?: boolean;
+  /** Mounted option rows from the collection (no DOM visibility scan). */
+  getVisibleOptionRows: () => HTMLElement[];
   onOpen: () => void;
   onClose: () => void;
   onToggleOption: (optionId: string) => void;
@@ -107,6 +109,7 @@ const activateOptionRowByMove = (
  * @param props.onToggleOption Toggle selection for an option value
  * @param props.onFocusLastTag Focus the last selected tag from an empty filter
  * @param props.setActiveDescendantId State setter for activedescendant
+ * @param props.getVisibleOptionRows
  */
 export const useComboboxOptionGridKeyboard = ({
   listboxRef,
@@ -115,6 +118,7 @@ export const useComboboxOptionGridKeyboard = ({
   isDisabled = false,
   activeDescendantId,
   canFocusLastTag = false,
+  getVisibleOptionRows,
   onOpen,
   onClose,
   onToggleOption,
@@ -146,9 +150,9 @@ export const useComboboxOptionGridKeyboard = ({
   const activateEdgeOption = useCallback(
     (edge: 'first' | 'last') => {
       setActiveNestedControlIndex(null);
-      activateOptionRowByMove(getVisibleOptionRows(listboxRef.current), -1, edge, setActiveDescendantId);
+      activateOptionRowByMove(getVisibleOptionRows(), -1, edge, setActiveDescendantId);
     },
-    [listboxRef, setActiveDescendantId],
+    [getVisibleOptionRows, setActiveDescendantId],
   );
 
   // Options exist only once the popover is open, so arrow keys on a closed combobox wait for that render.
@@ -197,12 +201,12 @@ export const useComboboxOptionGridKeyboard = ({
   }, [activeDescendantId, activeNestedControlIndex, listboxRef]);
 
   const getActiveRowState = useCallback(() => {
-    const visible = getVisibleOptionRows(listboxRef.current);
+    const visible = getVisibleOptionRows();
     const currentRow = activeDescendantId ? (visible.find((row) => row.id === activeDescendantId) ?? null) : null;
     const currentIndex = currentRow ? visible.indexOf(currentRow) : -1;
 
     return { visible, currentRow, currentIndex };
-  }, [activeDescendantId, listboxRef]);
+  }, [activeDescendantId, getVisibleOptionRows]);
 
   const onInputKeyDown = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/web-react/src/components/UNSTABLE_Combobox/utils.ts
+++ b/packages/web-react/src/components/UNSTABLE_Combobox/utils.ts
@@ -1,4 +1,4 @@
-import { Children, type ReactNode, isValidElement } from 'react';
+import { getNodeText } from '../../hooks';
 import {
   COMBOBOX_OPTION_CELL_CONTROL_SELECTOR,
   COMBOBOX_OPTION_ITEM_SELECTOR,
@@ -6,35 +6,7 @@ import {
   COMBOBOX_OPTION_VALUE_ATTR,
 } from './constants';
 
-/**
- * Flattens a ReactNode to plain text (for aria-labels).
- *
- * @param node React node
- */
-export const getNodeText = (node: ReactNode): string => {
-  if (node == null || typeof node === 'boolean') {
-    return '';
-  }
-
-  if (typeof node === 'string' || typeof node === 'number') {
-    return String(node);
-  }
-
-  if (Array.isArray(node)) {
-    return node.map(getNodeText).join('');
-  }
-
-  if (isValidElement<{ children?: ReactNode }>(node)) {
-    return getNodeText(node.props.children);
-  }
-
-  return '';
-};
-
-const isComboboxOption = (node: ReactNode) =>
-  isValidElement(node) && (node.type as { spiritComponent?: string })?.spiritComponent === 'UNSTABLE_ComboboxOption';
-
-const isOptionItemRole = (role?: string) => role === 'option' || role === 'row';
+export { getNodeText };
 
 /**
  * Namespaced DOM id for an option item (unique per Combobox instance).
@@ -52,79 +24,12 @@ export const getComboboxOptionDomId = (comboboxId: string, value: string): strin
 export const getOptionValueFromRow = (optionEl: HTMLElement): string =>
   optionEl.getAttribute(COMBOBOX_OPTION_VALUE_ATTR) || optionEl.id;
 
-/** Structured option metadata collected from Combobox children (Picker-style item collection). */
+/** Structured option metadata collected from Combobox children. */
 export interface ComboboxItem {
   isDisabled: boolean;
   key: string;
   label: string;
 }
-
-/**
- * Collects Combobox option items from children (`UNSTABLE_ComboboxOption` or `role="option"|"row"`).
- * Insertion order, unique by key.
- *
- * @param children Combobox option children
- */
-export const collectComboboxItems = (children: ReactNode): ComboboxItem[] => {
-  const items: ComboboxItem[] = [];
-  const seen = new Set<string>();
-
-  const push = (item: ComboboxItem) => {
-    if (!item.key || seen.has(item.key)) {
-      return;
-    }
-
-    seen.add(item.key);
-    items.push(item);
-  };
-
-  const traverse = (node: ReactNode) => {
-    Children.forEach(node, (child) => {
-      if (
-        !isValidElement<{
-          id?: string;
-          isDisabled?: boolean;
-          label?: string;
-          role?: string;
-          value?: string;
-          children?: ReactNode;
-        }>(child)
-      ) {
-        return;
-      }
-
-      const { id, isDisabled, label, role, value, children: childChildren } = child.props;
-
-      if (isComboboxOption(child) && value) {
-        push({
-          key: value,
-          label: label || getNodeText(childChildren),
-          isDisabled: Boolean(isDisabled),
-        });
-
-        return;
-      }
-
-      if (isOptionItemRole(role) && id) {
-        push({
-          key: id,
-          label: getNodeText(childChildren),
-          isDisabled: Boolean(isDisabled),
-        });
-
-        return;
-      }
-
-      if (childChildren != null) {
-        traverse(childChildren);
-      }
-    });
-  };
-
-  traverse(children);
-
-  return items;
-};
 
 /**
  * Readable label for an option item element.
@@ -141,25 +46,6 @@ export const getRowLabel = (optionEl: HTMLElement): string => {
   const firstCell = optionEl.querySelector('[role="gridcell"]');
 
   return (firstCell?.textContent ?? optionEl.textContent ?? '').trim();
-};
-
-/**
- * Visible option items inside the options widget (not hidden via `display: none` / `hidden`).
- *
- * @param optionsEl Options widget element (`listbox` or `grid`)
- */
-export const getVisibleOptionRows = (optionsEl: HTMLElement | null): HTMLElement[] => {
-  if (!optionsEl) {
-    return [];
-  }
-
-  return Array.from(optionsEl.querySelectorAll<HTMLElement>(COMBOBOX_OPTION_ITEM_SELECTOR)).filter((option) => {
-    if (option.hasAttribute('hidden') || option.getAttribute('aria-hidden') === 'true') {
-      return false;
-    }
-
-    return option.style.display !== 'none';
-  });
 };
 
 /**

--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_Picker.tsx
@@ -8,6 +8,7 @@ import {
   getSelectedKeys,
   isSingleSelectionMode,
   useAriaDescribedBy,
+  useCollection,
   useI18n,
   useOpenOnArrowDown,
   useSelectionGridKeyboard,
@@ -33,7 +34,6 @@ import UNSTABLE_PickerTrigger from './UNSTABLE_PickerTrigger';
 import { usePickerId } from './usePickerId';
 import { usePickerStyleProps } from './usePickerStyleProps';
 import {
-  collectPickerItems,
   getAggregatedTagLabel,
   getPickerItemLabelMap,
   getPickerSelectionGridKeyboardRowCount,
@@ -87,7 +87,16 @@ const _UNSTABLE_Picker = (props: SpiritUnstablePickerProps, ref: ForwardedRef<Sp
   const { styleProps, props: transferProps } = useStyleProps(restProps);
   const { labelId, pickerId, popoverId, selectionId, tagDescriptionId } = usePickerId(id);
 
-  const pickerItems = useMemo(() => collectPickerItems(children), [children]);
+  const collection = useCollection({ children });
+
+  const pickerItems = useMemo(
+    () =>
+      [...collection.getItemNodes()].map((node) => ({
+        value: node.key,
+        label: node.rendered,
+      })),
+    [collection],
+  );
 
   const pickerItemLabels = useMemo(() => getPickerItemLabelMap(pickerItems), [pickerItems]);
 

--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerGroup.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerGroup.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useId } from 'react';
+import React, { type ReactNode, useId } from 'react';
+import { getNodeText } from '../../hooks';
 import { FieldGroup } from '../FieldGroup';
 import { usePickerPopoverContext } from './PickerPopoverContext';
 import type { SpiritUnstablePickerGroupProps } from './types';
@@ -18,5 +19,15 @@ const UNSTABLE_PickerGroup = ({ children, label, ...restProps }: SpiritUnstableP
 };
 
 UNSTABLE_PickerGroup.spiritComponent = 'UNSTABLE_PickerGroup';
+
+UNSTABLE_PickerGroup.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'section' as const,
+    key: `group:${getNodeText(props.label as ReactNode)}`,
+    textValue: getNodeText(props.label as ReactNode),
+    hasChildNodes: true,
+    children: props.children as ReactNode,
+  };
+};
 
 export default UNSTABLE_PickerGroup;

--- a/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerItem.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/UNSTABLE_PickerItem.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { InputPositions } from '../../constants';
-import { getToggledSelectedKeys, isKeySelected, isSingleSelectionMode } from '../../hooks';
+import { getNodeText, getToggledSelectedKeys, isKeySelected, isSingleSelectionMode } from '../../hooks';
 import { Checkbox } from '../Checkbox';
 import { Radio } from '../Radio';
 import { usePickerPopoverContext } from './PickerPopoverContext';
@@ -36,5 +36,14 @@ const UNSTABLE_PickerItem = ({ children, value, ...restProps }: SpiritUnstablePi
 };
 
 UNSTABLE_PickerItem.spiritComponent = 'UNSTABLE_PickerItem';
+
+UNSTABLE_PickerItem.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'item' as const,
+    key: String(props.value ?? ''),
+    rendered: props.children as ReactNode,
+    textValue: getNodeText(props.children as ReactNode),
+  };
+};
 
 export default UNSTABLE_PickerItem;

--- a/packages/web-react/src/components/UNSTABLE_Picker/__tests__/utils.test.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Picker/__tests__/utils.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { createCollection } from '../../../hooks';
 import {
-  collectPickerItems,
   getAggregatedTagLabel,
   getNodeText,
   getPickerItemLabelMap,
@@ -10,7 +10,7 @@ import {
 import { UNSTABLE_PickerGroup, UNSTABLE_PickerItem } from '..';
 
 describe('UNSTABLE_Picker utils', () => {
-  it('collectPickerItems should collect picker items recursively', () => {
+  it('collection should collect picker items recursively through groups', () => {
     const children = (
       <UNSTABLE_PickerGroup label="Languages">
         <UNSTABLE_PickerItem value="cs">Czech</UNSTABLE_PickerItem>
@@ -21,14 +21,16 @@ describe('UNSTABLE_Picker utils', () => {
       </UNSTABLE_PickerGroup>
     );
 
-    expect(collectPickerItems(children)).toEqual([
+    const collection = createCollection({ children });
+
+    expect([...collection.getItemNodes()].map((node) => ({ value: node.key, label: node.rendered }))).toEqual([
       { value: 'cs', label: 'Czech' },
       { value: 'dk', label: 'Danish' },
     ]);
   });
 
-  it('collectPickerItems should ignore valid elements without children', () => {
-    expect(collectPickerItems(<span />)).toEqual([]);
+  it('collection should ignore valid elements without collection nodes', () => {
+    expect(createCollection({ children: <span /> }).size).toBe(0);
   });
 
   it('getPickerItemLabelMap should build labels map from picker items', () => {

--- a/packages/web-react/src/components/UNSTABLE_Picker/utils.ts
+++ b/packages/web-react/src/components/UNSTABLE_Picker/utils.ts
@@ -1,39 +1,8 @@
-import { Children, type ReactNode, isValidElement } from 'react';
+import type { ReactNode } from 'react';
+import { getNodeText } from '../../hooks';
 import type { UnstablePickerItemData } from './types';
 
-const isPickerItem = (node: ReactNode) =>
-  isValidElement(node) && (node.type as { spiritComponent?: string })?.spiritComponent === 'UNSTABLE_PickerItem';
-
-const normalizeWhitespace = (text: string) => text.replace(/\s+/g, ' ').trim();
-
-export const collectPickerItems = (children: ReactNode): UnstablePickerItemData[] => {
-  const items: UnstablePickerItemData[] = [];
-
-  const traverse = (node: ReactNode) => {
-    Children.forEach(node, (child) => {
-      if (!isValidElement(child)) {
-        return;
-      }
-
-      if (isPickerItem(child)) {
-        items.push({
-          label: child.props.children as ReactNode,
-          value: child.props.value as string,
-        });
-
-        return;
-      }
-
-      if (child.props?.children) {
-        traverse(child.props.children);
-      }
-    });
-  };
-
-  traverse(children);
-
-  return items;
-};
+export { getNodeText };
 
 export const getPickerItemLabelMap = (items: UnstablePickerItemData[]): Record<string, ReactNode> => {
   const labelsMap: Record<string, ReactNode> = {};
@@ -50,32 +19,6 @@ export const getSelectedItems = (keys: string[], labels: Record<string, ReactNod
     label: labels[value] ?? value,
     value,
   }));
-
-export const getNodeText = (value: ReactNode): string => {
-  const collect = (node: ReactNode): string => {
-    if (node == null || typeof node === 'boolean') {
-      return '';
-    }
-
-    if (typeof node === 'string' || typeof node === 'number') {
-      return String(node);
-    }
-
-    if (Array.isArray(node)) {
-      return node.map(collect).filter(Boolean).join(' ');
-    }
-
-    if (isValidElement(node)) {
-      return collect(node.props.children as ReactNode);
-    }
-
-    return '';
-  };
-
-  const text = collect(value);
-
-  return normalizeWhitespace(text);
-};
 
 export const getAggregatedTagLabel = (label: string, selectedItems: UnstablePickerItemData[]): ReactNode => {
   if (selectedItems.length > 1) {

--- a/packages/web-react/src/hooks/collection/README.md
+++ b/packages/web-react/src/hooks/collection/README.md
@@ -1,0 +1,118 @@
+# Collection
+
+[Collections][collection-pattern] are a stable tree of nodes built from React children (or a dynamic items array) without touching the DOM. They provide item identity, labels, hierarchy, and disabled state for components such as Picker and Combobox.
+
+## Features
+
+- Builds a stable node tree from the element tree — never from live DOM queries
+- Item and section components declare themselves via static `getCollectionNode` on the component type
+- Supports static children and a dynamic `items` + `renderItem` builder path
+- Sections (groups) participate in the tree; consumers can still iterate flat item nodes
+- `filterCollection` returns a filtered view for navigation / future consumers
+- Composes with Selection (`useSelectionState`) — Collection does not own selection
+
+## Anatomy
+
+Collection item/section components expose a static `getCollectionNode` generator that yields partial nodes (`type`, `key`, `textValue`, …).
+
+`createCollection` / `useCollection` walks children, calls `getCollectionNode` when present, and builds a `Collection` with key lookup and next/prev helpers.
+
+Transparent wrappers without `getCollectionNode` are recursed into. Combobox also recognizes custom `role="option"|"row"` + `id` rows as a parity escape hatch.
+
+## GetCollectionNode
+
+Static method on an item or section component type. Yields one or more partial collection nodes.
+
+### API
+
+```js
+Component.getCollectionNode = function* (props: object): Iterable<CollectionNodePartial>
+```
+
+## CreateCollection
+
+Pure builder that walks children / dynamic items into a `Collection`.
+
+### API
+
+```js
+createCollection(options: CreateCollectionOptions): Collection
+```
+
+## useCollection
+
+React wrapper around `createCollection` (memoized).
+
+### API
+
+```js
+useCollection(options: CreateCollectionOptions): Collection
+```
+
+## FilterCollection
+
+Returns a new `Collection` containing only matching item nodes. Sections without matches are omitted.
+
+### API
+
+```js
+filterCollection(collection: Collection, predicate: (node) => boolean): Collection
+```
+
+## GetNodeText
+
+Flattens a `ReactNode` to plain text for `textValue` / aria labels (whitespace normalized).
+
+### API
+
+```js
+getNodeText(node: ReactNode): string
+```
+
+## Example
+
+```jsx
+import { getNodeText, useCollection } from '@alma-oss/spirit-web-react';
+
+const MyItem = (props) => <div>{props.children}</div>;
+MyItem.getCollectionNode = function* (props) {
+  yield {
+    type: 'item',
+    key: String(props.value ?? ''),
+    rendered: props.children,
+    textValue: getNodeText(props.children),
+  };
+};
+
+const MyGroup = (props) => <fieldset>{props.children}</fieldset>;
+MyGroup.getCollectionNode = function* (props) {
+  yield {
+    type: 'section',
+    key: `group:${getNodeText(props.label)}`,
+    textValue: getNodeText(props.label),
+    hasChildNodes: true,
+    children: props.children,
+  };
+};
+
+const Example = ({ children }) => {
+  const collection = useCollection({ children });
+
+  return (
+    <ul>
+      {[...collection.getItemNodes()].map((node) => (
+        <li key={node.key}>{node.textValue}</li>
+      ))}
+    </ul>
+  );
+};
+
+<Example>
+  <MyGroup label="Languages">
+    <MyItem value="cs">Czech</MyItem>
+    <MyItem value="en">English</MyItem>
+  </MyGroup>
+</Example>;
+```
+
+[collection-pattern]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/content/collections.md

--- a/packages/web-react/src/hooks/collection/__tests__/createCollection.test.tsx
+++ b/packages/web-react/src/hooks/collection/__tests__/createCollection.test.tsx
@@ -1,0 +1,160 @@
+import React, { type ReactNode } from 'react';
+import { createCollection } from '../createCollection';
+import { getNodeText } from '../getNodeText';
+
+const TestItem = ({ children, value, isDisabled }: { children?: ReactNode; value?: string; isDisabled?: boolean }) => (
+  <div data-value={value} data-disabled={isDisabled}>
+    {children}
+  </div>
+);
+TestItem.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'item' as const,
+    key: String(props.value ?? ''),
+    rendered: props.children as ReactNode,
+    textValue: getNodeText(props.children as ReactNode),
+    isDisabled: Boolean(props.isDisabled),
+  };
+};
+
+const TestSection = ({ children, label }: { children?: ReactNode; label?: ReactNode }) => (
+  <div data-label={getNodeText(label)}>{children}</div>
+);
+TestSection.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'section' as const,
+    key: `group:${getNodeText(props.label as ReactNode)}`,
+    textValue: getNodeText(props.label as ReactNode),
+    hasChildNodes: true,
+    children: props.children as ReactNode,
+  };
+};
+
+describe('createCollection', () => {
+  it('should collect items via getCollectionNode in document order', () => {
+    const collection = createCollection({
+      children: (
+        <>
+          <TestItem value="cs">Czech</TestItem>
+          <TestItem value="en" isDisabled>
+            English
+          </TestItem>
+        </>
+      ),
+    });
+
+    expect(collection.size).toBe(2);
+    expect([...collection.getKeys()]).toEqual(['cs', 'en']);
+    expect(collection.getItem('en')?.isDisabled).toBe(true);
+    expect(collection.getItem('cs')?.textValue).toBe('Czech');
+    expect(collection.getFirstKey()).toBe('cs');
+    expect(collection.getLastKey()).toBe('en');
+    expect(collection.getKeyAfter('cs')).toBe('en');
+    expect(collection.getKeyBefore('en')).toBe('cs');
+  });
+
+  it('should represent sections and still expose flat item nodes', () => {
+    const collection = createCollection({
+      children: (
+        <TestSection label="Languages">
+          <div>
+            <TestItem value="cs">Czech</TestItem>
+            <TestItem value="dk">Danish</TestItem>
+          </div>
+        </TestSection>
+      ),
+    });
+
+    const roots = [...collection.getChildren('')];
+
+    expect(roots).toHaveLength(1);
+    expect(roots[0].type).toBe('section');
+    expect(roots[0].textValue).toBe('Languages');
+
+    expect([...collection.getItemNodes()].map((node) => ({ key: node.key, rendered: node.rendered }))).toEqual([
+      { key: 'cs', rendered: 'Czech' },
+      { key: 'dk', rendered: 'Danish' },
+    ]);
+  });
+
+  it('should support custom role option/row escape hatch', () => {
+    const collection = createCollection({
+      children: React.createElement(
+        'div',
+        {
+          role: 'option',
+          id: 'custom-1',
+          isDisabled: true,
+        } as React.HTMLAttributes<HTMLDivElement> & { isDisabled?: boolean },
+        'Custom',
+      ),
+    });
+
+    expect(collection.size).toBe(1);
+    expect(collection.getItem('custom-1')?.textValue).toBe('Custom');
+    expect(collection.getItem('custom-1')?.isDisabled).toBe(true);
+  });
+
+  it('should build the same items from a dynamic items path', () => {
+    const items = [
+      { id: 'cs', label: 'Czech' },
+      { id: 'en', label: 'English' },
+    ];
+
+    const dynamic = createCollection({
+      items,
+      renderItem: (item) => (
+        <TestItem key={item.id} value={item.id}>
+          {item.label}
+        </TestItem>
+      ),
+    });
+
+    const staticCollection = createCollection({
+      children: (
+        <>
+          <TestItem value="cs">Czech</TestItem>
+          <TestItem value="en">English</TestItem>
+        </>
+      ),
+    });
+
+    expect([...dynamic.getKeys()]).toEqual([...staticCollection.getKeys()]);
+    expect([...dynamic].map((node) => node.textValue)).toEqual([...staticCollection].map((node) => node.textValue));
+  });
+
+  it('should dedupe colliding section keys with an index suffix', () => {
+    const collection = createCollection({
+      children: (
+        <>
+          <TestSection label="Same">
+            <TestItem value="a">A</TestItem>
+          </TestSection>
+          <TestSection label="Same">
+            <TestItem value="b">B</TestItem>
+          </TestSection>
+        </>
+      ),
+    });
+
+    const roots = [...collection.getChildren('')];
+
+    expect(roots.map((node) => node.key)).toEqual(['group:Same', 'group:Same#1']);
+  });
+
+  it('should skip duplicate item keys instead of suffixing them', () => {
+    const collection = createCollection({
+      children: (
+        <>
+          <TestItem value="cs">Czech</TestItem>
+          <TestItem value="cs">Czech duplicate</TestItem>
+          <TestItem value="en">English</TestItem>
+        </>
+      ),
+    });
+
+    expect([...collection.getKeys()]).toEqual(['cs', 'en']);
+    expect(collection.getItem('cs')?.textValue).toBe('Czech');
+    expect(collection.getItem('cs#1')).toBeUndefined();
+  });
+});

--- a/packages/web-react/src/hooks/collection/__tests__/filterCollection.test.ts
+++ b/packages/web-react/src/hooks/collection/__tests__/filterCollection.test.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+import { createCollection } from '../createCollection';
+import { filterCollection } from '../filterCollection';
+import { getNodeText } from '../getNodeText';
+
+const TestItem = ({ children, value }: { children?: React.ReactNode; value?: string }) =>
+  React.createElement('div', { 'data-value': value }, children);
+TestItem.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'item' as const,
+    key: String(props.value ?? ''),
+    textValue: getNodeText(props.children as React.ReactNode),
+    rendered: props.children as React.ReactNode,
+  };
+};
+
+const TestSection = ({ children, label }: { children?: React.ReactNode; label?: React.ReactNode }) =>
+  React.createElement('div', { 'data-label': getNodeText(label) }, children);
+TestSection.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'section' as const,
+    key: `group:${getNodeText(props.label as React.ReactNode)}`,
+    textValue: getNodeText(props.label as React.ReactNode),
+    hasChildNodes: true,
+    children: props.children as React.ReactNode,
+  };
+};
+
+describe('filterCollection', () => {
+  it('should keep matching items and skip non-matches in navigation', () => {
+    const collection = createCollection({
+      children: React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(TestItem, { value: 'cs' }, 'Czech'),
+        React.createElement(TestItem, { value: 'en' }, 'English'),
+        React.createElement(TestItem, { value: 'pl' }, 'Polish'),
+      ),
+    });
+
+    const filtered = filterCollection(collection, (node) => node.textValue.toLowerCase().includes('ish'));
+
+    expect([...filtered.getKeys()]).toEqual(['en', 'pl']);
+    expect(filtered.getFirstKey()).toBe('en');
+    expect(filtered.getKeyAfter('en')).toBe('pl');
+    expect(filtered.getKeyBefore('pl')).toBe('en');
+    expect(filtered.getItem('cs')).toBeUndefined();
+  });
+
+  it('should omit empty sections after filtering', () => {
+    const collection = createCollection({
+      children: React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(TestSection, { label: 'Match' }, React.createElement(TestItem, { value: 'en' }, 'English')),
+        React.createElement(
+          TestSection,
+          { label: 'No match' },
+          React.createElement(TestItem, { value: 'cs' }, 'Czech'),
+        ),
+      ),
+    });
+
+    const filtered = filterCollection(collection, (node) => node.textValue.toLowerCase().includes('eng'));
+
+    expect(filtered.size).toBe(1);
+    expect([...filtered.getKeys()]).toEqual(['en']);
+    expect([...filtered.getChildren('')]).toHaveLength(1);
+    expect([...filtered.getChildren('')][0].type).toBe('section');
+  });
+});

--- a/packages/web-react/src/hooks/collection/__tests__/getNodeText.test.tsx
+++ b/packages/web-react/src/hooks/collection/__tests__/getNodeText.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { getNodeText } from '../getNodeText';
+
+describe('getNodeText', () => {
+  it('should return empty string for nullish and boolean values', () => {
+    expect(getNodeText(null)).toBe('');
+    expect(getNodeText(undefined)).toBe('');
+    expect(getNodeText(false)).toBe('');
+  });
+
+  it('should stringify primitives', () => {
+    expect(getNodeText('Czech')).toBe('Czech');
+    expect(getNodeText(42)).toBe('42');
+  });
+
+  it('should flatten nested JSX and normalize whitespace', () => {
+    expect(
+      getNodeText(
+        <>
+          {'  Czech  '}
+          <em> Republic </em>
+        </>,
+      ),
+    ).toBe('Czech Republic');
+  });
+
+  it('should join array children with spaces', () => {
+    expect(getNodeText(['Hello', ' ', 'world'])).toBe('Hello world');
+  });
+});

--- a/packages/web-react/src/hooks/collection/__tests__/useCollection.test.tsx
+++ b/packages/web-react/src/hooks/collection/__tests__/useCollection.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import React, { type ReactNode } from 'react';
+import { getNodeText } from '../getNodeText';
+import { useCollection } from '../useCollection';
+
+const TestItem = ({ children, value }: { children?: ReactNode; value?: string }) => (
+  <div data-value={value}>{children}</div>
+);
+TestItem.getCollectionNode = function* getCollectionNode(props: Record<string, unknown>) {
+  yield {
+    type: 'item' as const,
+    key: String(props.value ?? ''),
+    textValue: getNodeText(props.children as ReactNode),
+  };
+};
+
+describe('useCollection', () => {
+  it('should build a collection from children', () => {
+    const { result } = renderHook(() =>
+      useCollection({
+        children: <TestItem value="cs">Czech</TestItem>,
+      }),
+    );
+
+    expect(result.current.size).toBe(1);
+    expect(result.current.getFirstKey()).toBe('cs');
+  });
+
+  it('should update when children change', () => {
+    const { result, rerender } = renderHook(({ children }) => useCollection({ children }), {
+      initialProps: {
+        children: (<TestItem value="cs">Czech</TestItem>) as ReactNode,
+      },
+    });
+
+    expect(result.current.size).toBe(1);
+
+    rerender({
+      children: (
+        <>
+          <TestItem value="cs">Czech</TestItem>
+          <TestItem value="en">English</TestItem>
+        </>
+      ),
+    });
+
+    expect(result.current.size).toBe(2);
+    expect([...result.current.getKeys()]).toEqual(['cs', 'en']);
+  });
+});

--- a/packages/web-react/src/hooks/collection/createCollection.ts
+++ b/packages/web-react/src/hooks/collection/createCollection.ts
@@ -1,0 +1,179 @@
+import { Children, type ReactElement, type ReactNode, isValidElement } from 'react';
+import { createCollectionFromNodes } from './createCollectionFromNodes';
+import { getNodeText } from './getNodeText';
+import type {
+  Collection,
+  CollectionComponentType,
+  CollectionNode,
+  CollectionNodePartial,
+  CreateCollectionOptions,
+} from './types';
+
+const isOptionItemRole = (role?: string) => role === 'option' || role === 'row';
+
+const toIterable = <T>(value: Generator<T, void, undefined> | Iterable<T>): Iterable<T> => value;
+
+const ensureUniqueKey = (key: string, seen: Map<string, number>): string => {
+  const count = seen.get(key) ?? 0;
+  seen.set(key, count + 1);
+
+  if (count === 0) {
+    return key;
+  }
+
+  return `${key}#${count}`;
+};
+
+type WalkContext<T> = {
+  itemNodes: CollectionNode<T>[];
+  keyCounts: Map<string, number>;
+  siblingCounter: { value: number };
+};
+
+function walkNodes<T>(node: ReactNode, parentKey: string | null, context: WalkContext<T>): CollectionNode<T>[] {
+  const result: CollectionNode<T>[] = [];
+
+  Children.forEach(node, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+
+    const type = child.type as CollectionComponentType;
+    const props = child.props as Record<string, unknown>;
+
+    if (typeof type?.getCollectionNode === 'function') {
+      for (const partial of toIterable(type.getCollectionNode(props))) {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion with materializePartial
+        result.push(...materializePartial(partial, parentKey, context));
+      }
+
+      return;
+    }
+
+    const role = typeof props.role === 'string' ? props.role : undefined;
+    const id = typeof props.id === 'string' ? props.id : undefined;
+
+    if (isOptionItemRole(role) && id) {
+      const partial: CollectionNodePartial = {
+        type: 'item',
+        key: id,
+        textValue: getNodeText(props.children as ReactNode),
+        isDisabled: Boolean(props.isDisabled),
+        props,
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion with materializePartial
+      result.push(...materializePartial(partial, parentKey, context));
+
+      return;
+    }
+
+    if (props.children != null) {
+      result.push(...walkNodes(props.children as ReactNode, parentKey, context));
+    }
+  });
+
+  return result;
+}
+
+function materializePartial<T>(
+  partial: CollectionNodePartial,
+  parentKey: string | null,
+  context: WalkContext<T>,
+): CollectionNode<T>[] {
+  if (!partial.key) {
+    return [];
+  }
+
+  // Item keys are consumer-controlled option values — keep them stable and skip
+  // duplicates instead of suffixing (Picker/Combobox treat node.key as the value).
+  // Section keys may be derived (e.g. group labels); suffix those for uniqueness.
+  let { key } = partial;
+
+  if (partial.type === 'item') {
+    if ((context.keyCounts.get(key) ?? 0) > 0) {
+      return [];
+    }
+
+    context.keyCounts.set(key, 1);
+  } else {
+    key = ensureUniqueKey(key, context.keyCounts);
+  }
+
+  const index = context.siblingCounter.value;
+
+  // Shared counter for document-order indices among siblings.
+  // eslint-disable-next-line no-param-reassign -- intentional shared walk state
+  context.siblingCounter.value += 1;
+
+  const childNodes: CollectionNode<T>[] =
+    partial.hasChildNodes || partial.children != null
+      ? walkNodes(partial.children, key, {
+          itemNodes: context.itemNodes,
+          keyCounts: context.keyCounts,
+          siblingCounter: { value: 0 },
+        })
+      : [];
+
+  const collectionNode: CollectionNode<T> = {
+    key,
+    type: partial.type,
+    textValue: partial.textValue ?? '',
+    rendered: partial.rendered,
+    isDisabled: partial.isDisabled,
+    props: partial.props,
+    hasChildNodes: childNodes.length > 0,
+    childNodes,
+    parentKey,
+    index,
+  };
+
+  if (partial.type === 'item') {
+    context.itemNodes.push(collectionNode);
+  }
+
+  return [collectionNode];
+}
+
+const buildFromChildren = <T>(
+  children: ReactNode | undefined,
+): {
+  rootNodes: CollectionNode<T>[];
+  itemNodes: CollectionNode<T>[];
+} => {
+  const itemNodes: CollectionNode<T>[] = [];
+  const keyCounts = new Map<string, number>();
+  const rootNodes = walkNodes<T>(children, null, {
+    itemNodes,
+    keyCounts,
+    siblingCounter: { value: 0 },
+  });
+
+  return { rootNodes, itemNodes };
+};
+
+/**
+ * Builds a Collection tree from static children and/or a dynamic items array.
+ * Never touches the DOM — identity comes from `getCollectionNode` / role fallback.
+ *
+ * @param options Builder options
+ */
+export const createCollection = <T = unknown>(options: CreateCollectionOptions<T> = {}): Collection<T> => {
+  const { children, items, renderItem } = options;
+
+  let sourceChildren = children;
+
+  if (items != null && renderItem) {
+    const rendered: ReactElement[] = [];
+
+    for (const item of items) {
+      rendered.push(renderItem(item));
+    }
+
+    sourceChildren = rendered;
+  }
+
+  const { rootNodes, itemNodes } = buildFromChildren<T>(sourceChildren);
+
+  return createCollectionFromNodes(rootNodes, itemNodes);
+};

--- a/packages/web-react/src/hooks/collection/createCollectionFromNodes.ts
+++ b/packages/web-react/src/hooks/collection/createCollectionFromNodes.ts
@@ -1,0 +1,56 @@
+import type { Collection, CollectionNode } from './types';
+
+/**
+ * Builds a Collection API object from an already-materialized node tree.
+ * Shared by `createCollection` and `filterCollection`.
+ *
+ * @param rootNodes Root nodes (items and/or sections)
+ * @param itemNodes Flat list of item nodes in document order
+ */
+export const createCollectionFromNodes = <T>(
+  rootNodes: CollectionNode<T>[],
+  itemNodes: CollectionNode<T>[],
+): Collection<T> => {
+  const childrenByKey = new Map<string, CollectionNode<T>[]>();
+  const itemByKey = new Map(itemNodes.map((node) => [node.key, node]));
+  const indexByKey = new Map(itemNodes.map((node, index) => [node.key, index]));
+
+  const indexTree = (nodes: CollectionNode<T>[]) => {
+    for (const node of nodes) {
+      childrenByKey.set(node.key, [...node.childNodes]);
+      indexTree([...node.childNodes]);
+    }
+  };
+
+  indexTree(rootNodes);
+  childrenByKey.set('', rootNodes);
+
+  return {
+    size: itemNodes.length,
+    getKeys: () => itemNodes.map((node) => node.key),
+    getItem: (key: string) => itemByKey.get(key),
+    getFirstKey: () => itemNodes[0]?.key ?? null,
+    getLastKey: () => itemNodes[itemNodes.length - 1]?.key ?? null,
+    getKeyBefore: (key: string) => {
+      const index = indexByKey.get(key);
+
+      if (index == null || index <= 0) {
+        return null;
+      }
+
+      return itemNodes[index - 1]?.key ?? null;
+    },
+    getKeyAfter: (key: string) => {
+      const index = indexByKey.get(key);
+
+      if (index == null || index >= itemNodes.length - 1) {
+        return null;
+      }
+
+      return itemNodes[index + 1]?.key ?? null;
+    },
+    getChildren: (key: string) => childrenByKey.get(key) ?? [],
+    getItemNodes: () => itemNodes,
+    [Symbol.iterator]: () => itemNodes[Symbol.iterator](),
+  };
+};

--- a/packages/web-react/src/hooks/collection/filterCollection.ts
+++ b/packages/web-react/src/hooks/collection/filterCollection.ts
@@ -1,0 +1,58 @@
+import { createCollectionFromNodes } from './createCollectionFromNodes';
+import type { Collection, CollectionNode } from './types';
+
+const filterTree = <T>(
+  nodes: Iterable<CollectionNode<T>>,
+  predicate: (node: CollectionNode<T>) => boolean,
+  itemNodes: CollectionNode<T>[],
+): CollectionNode<T>[] => {
+  const result: CollectionNode<T>[] = [];
+
+  for (const node of nodes) {
+    if (node.type === 'item') {
+      if (predicate(node)) {
+        const filtered: CollectionNode<T> = {
+          ...node,
+          childNodes: [],
+          hasChildNodes: false,
+        };
+
+        itemNodes.push(filtered);
+        result.push(filtered);
+      }
+    } else {
+      const childNodes = filterTree(node.childNodes, predicate, itemNodes);
+
+      if (childNodes.length > 0) {
+        result.push({
+          ...node,
+          childNodes,
+          hasChildNodes: true,
+        });
+      }
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Returns a new Collection containing only item nodes that match `predicate`.
+ * Sections without matching children are omitted.
+ *
+ * @param collection Source collection
+ * @param predicate Match function for item nodes
+ */
+export const filterCollection = <T = unknown>(
+  collection: Collection<T>,
+  predicate: (node: CollectionNode<T>) => boolean,
+): Collection<T> => {
+  const itemNodes: CollectionNode<T>[] = [];
+  const roots = [...collection.getChildren('')];
+  const filteredRoots =
+    roots.length > 0
+      ? filterTree(roots, predicate, itemNodes)
+      : filterTree([...collection.getItemNodes()], predicate, itemNodes);
+
+  return createCollectionFromNodes(filteredRoots, itemNodes);
+};

--- a/packages/web-react/src/hooks/collection/getNodeText.ts
+++ b/packages/web-react/src/hooks/collection/getNodeText.ts
@@ -1,0 +1,31 @@
+import { type ReactNode, isValidElement } from 'react';
+
+const normalizeWhitespace = (text: string) => text.replace(/\s+/g, ' ').trim();
+
+const collectNodeText = (value: ReactNode): string => {
+  if (value == null || typeof value === 'boolean') {
+    return '';
+  }
+
+  if (typeof value === 'string' || typeof value === 'number') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(collectNodeText).filter(Boolean).join(' ');
+  }
+
+  if (isValidElement(value)) {
+    return collectNodeText((value.props as { children?: ReactNode }).children);
+  }
+
+  return '';
+};
+
+/**
+ * Flattens a ReactNode to plain text (for aria-labels / collection textValue).
+ * Joins array children with spaces and normalizes whitespace.
+ *
+ * @param node React node
+ */
+export const getNodeText = (node: ReactNode): string => normalizeWhitespace(collectNodeText(node));

--- a/packages/web-react/src/hooks/collection/index.ts
+++ b/packages/web-react/src/hooks/collection/index.ts
@@ -1,0 +1,13 @@
+export { getNodeText } from './getNodeText';
+export { createCollection } from './createCollection';
+export { filterCollection } from './filterCollection';
+export { useCollection } from './useCollection';
+export type {
+  Collection,
+  CollectionComponentType,
+  CollectionNode,
+  CollectionNodePartial,
+  CollectionNodeType,
+  CreateCollectionOptions,
+  GetCollectionNode,
+} from './types';

--- a/packages/web-react/src/hooks/collection/types.ts
+++ b/packages/web-react/src/hooks/collection/types.ts
@@ -1,0 +1,63 @@
+import type { ReactElement, ReactNode } from 'react';
+
+export type CollectionNodeType = 'item' | 'section';
+
+/**
+ * Partial node returned from `getCollectionNode`.
+ * The builder fills `parentKey`, `index`, and resolved `childNodes`.
+ */
+export interface CollectionNodePartial {
+  type: CollectionNodeType;
+  key: string;
+  textValue?: string;
+  rendered?: ReactNode;
+  isDisabled?: boolean;
+  props?: Record<string, unknown>;
+  /** Section: child elements to walk; omit/empty for leaf items */
+  hasChildNodes?: boolean;
+  children?: ReactNode;
+}
+
+export type GetCollectionNode = (
+  props: Record<string, unknown>,
+) => Generator<CollectionNodePartial, void, undefined> | Iterable<CollectionNodePartial>;
+
+export interface CollectionComponentType {
+  getCollectionNode?: GetCollectionNode;
+  spiritComponent?: string;
+}
+
+export interface CollectionNode<T = unknown> {
+  key: string;
+  type: CollectionNodeType;
+  value?: T;
+  textValue: string;
+  rendered?: ReactNode;
+  isDisabled?: boolean;
+  props?: Record<string, unknown>;
+  hasChildNodes: boolean;
+  childNodes: Iterable<CollectionNode<T>>;
+  parentKey: string | null;
+  index: number;
+}
+
+export interface Collection<T = unknown> {
+  /** Number of **item** nodes (sections are not counted). */
+  size: number;
+  getKeys(): Iterable<string>;
+  getItem(key: string): CollectionNode<T> | undefined;
+  getFirstKey(): string | null;
+  getLastKey(): string | null;
+  getKeyBefore(key: string): string | null;
+  getKeyAfter(key: string): string | null;
+  getChildren(key: string): Iterable<CollectionNode<T>>;
+  getItemNodes(): Iterable<CollectionNode<T>>;
+  [Symbol.iterator](): Iterator<CollectionNode<T>>;
+}
+
+export interface CreateCollectionOptions<T = unknown> {
+  children?: ReactNode;
+  /** Dynamic path — builder-only; not a public Picker/Combobox prop. */
+  items?: Iterable<T>;
+  renderItem?: (item: T) => ReactElement;
+}

--- a/packages/web-react/src/hooks/collection/useCollection.ts
+++ b/packages/web-react/src/hooks/collection/useCollection.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMemo } from 'react';
+import { createCollection } from './createCollection';
+import type { Collection, CreateCollectionOptions } from './types';
+
+/**
+ * Builds a memoized Collection from children and/or dynamic items.
+ *
+ * @param options Builder options (`children`, optional `items` + `renderItem`)
+ */
+export const useCollection = <T = unknown>(options: CreateCollectionOptions<T>): Collection<T> => {
+  const { children, items, renderItem } = options;
+
+  return useMemo(
+    () =>
+      createCollection({
+        children,
+        items,
+        renderItem,
+      }),
+    [children, items, renderItem],
+  );
+};

--- a/packages/web-react/src/hooks/index.ts
+++ b/packages/web-react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './collection';
 export * from './styleProps';
 export * from './useAutoFocus';
 export * from './useAlignmentClass';


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Picker and Combobox each walked JSX children (and Combobox also fell back to live DOM queries) to resolve option identity, labels, and disabled state — duplicated and fragile. This adds a shared Collection abstraction under `hooks/collection/` (Adobe-style `getCollectionNode` on item/section components) and migrates both components onto it so identity comes from the element tree, not the DOM.

Public APIs and Combobox’s consumer-owned filtering (`optionKeys` + label cache) stay unchanged; `filterCollection` and a dynamic builder path are available for tests/future use but are not wired into Combobox filtering. `UNSTABLE_PickerGroup` is represented as a section node while tags still iterate flat items.

### Additional context

### Issue reference

https://jira.almacareer.tech/browse/DS-2699
