### PR TITLE
chore(deps): group @babel packages including major updates

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,6 +22,11 @@
       "matchPackageNames": ["/^@supernovaio/"]
     },
     {
+      "groupName": "monorepo:babel",
+      "groupSlug": "monorepo-babel",
+      "matchPackageNames": ["/^@babel/", "/^@types\\/babel__/"]
+    },
+    {
       "groupName": "eslint plugins and configs non-major",
       "groupSlug": "eslint-plugins-configs-non-major",
       "matchUpdateTypes": ["minor", "patch"],
@@ -31,7 +36,7 @@
       "groupName": "compile tools non-major",
       "groupSlug": "compile-tools-non-major",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["/^@babel/", "/^@swc/"]
+      "matchPackageNames": ["/^@swc/"]
     },
     {
       "groupName": "types non-major",


### PR DESCRIPTION
## Description

Renovate PR #2864 updated only `@babel/core` to v8, leaving `@babel/preset-react`, `@babel/preset-env`, `@babel/preset-typescript`, and `@babel/eslint-parser` behind on 7.x — Babel packages must move to a new major in lockstep, so a partial bump breaks the toolchain. This adds a dedicated `monorepo:babel` Renovate group (matching `@babel/*` and `@types/babel__*`) with no `matchUpdateTypes` restriction, so future major bumps propose all Babel packages together in one PR instead of one-by-one.

### Additional context

`@babel` was removed from the existing `compile tools non-major` group to avoid two rules matching the same packages. `@rollup/plugin-babel` is intentionally excluded from the new group since it's versioned independently as a rollup plugin.

### Issue reference

_none_