### PR TITLE
fix(web): align `Tag` radius with `InputContainer` in picker

### DIFF
--- a/packages/web/src/scss/components/InputContainer/_InputContainer.scss
+++ b/packages/web/src/scss/components/InputContainer/_InputContainer.scss
@@ -78,7 +78,11 @@
 
     @each $breakpoint-name, $breakpoint-value in tokens.$breakpoints {
         @include breakpoint.up($breakpoint-value) {
-            border-radius: var(--#{tokens.$css-variable-prefix}input-container-border-radius-#{$breakpoint-name});
+            --#{tokens.$css-variable-prefix}input-container-border-radius: var(
+                --#{tokens.$css-variable-prefix}input-container-border-radius-#{$breakpoint-name}
+            );
+
+            border-radius: var(--#{tokens.$css-variable-prefix}input-container-border-radius);
         }
     }
 }

--- a/packages/web/src/scss/components/Tag/_theme.scss
+++ b/packages/web/src/scss/components/Tag/_theme.scss
@@ -1,10 +1,31 @@
+// 1. Nested Tag radius. Parents may set `--tag-border-radius` to
+//    `container-radius - border-width - container-padding`. CSS has no `if`, so this mix is
+//    equivalent to: use the inherited value when it is positive, otherwise keep the default.
+//
+//    1. `var(--tag-border-radius, 1px)` inside `sign()`: dummy 1px so `sign()` always receives a
+//       dimension. An unset custom property would invalidate the whole `calc()`. This fallback is
+//       not the visible radius; when the property is unset, `sign(1px)` is 1 and the next `var()`
+//       supplies `$_default-border-radius`.
+//    2. `sign()`: -1 if negative, 0 if zero, 1 if positive.
+//    3. `max(0, sign(...))`: 1 only when the inherited radius is positive, otherwise 0. This is the
+//       switch used by both products below.
+//    4. First product: `switch * var(--tag-border-radius, default)` — inherited radius when the
+//       switch is 1 (or the default, when the property is unset and the dummy 1px made the switch 1).
+//    5. Second product: `(1 - switch) * default` — default radius when the switch is 0 (explicit 0
+//       or a negative inset from a container tighter than the Tag corner).
+
 @use '@tokens' as tokens;
 @use '../../settings/dictionaries';
 @use '../../tools/units';
 
 $border-width: tokens.$border-width-100;
 $border-style: solid;
-$border-radius: tokens.$radius-300;
+$_default-border-radius: tokens.$radius-300;
+$border-radius: calc(
+    max(0, sign(var(--#{tokens.$css-variable-prefix}tag-border-radius, 1px))) *
+        var(--#{tokens.$css-variable-prefix}tag-border-radius, #{$_default-border-radius}) +
+        (1 - max(0, sign(var(--#{tokens.$css-variable-prefix}tag-border-radius, 1px)))) * #{$_default-border-radius}
+); // 1.
 
 $size-dictionary: dictionaries.$size-extended;
 $size-config: (

--- a/packages/web/src/scss/components/UNSTABLE_Combobox/_UNSTABLE_ComboboxSelection.scss
+++ b/packages/web/src/scss/components/UNSTABLE_Combobox/_UNSTABLE_ComboboxSelection.scss
@@ -1,9 +1,19 @@
 // 1. Elevate interactive elements above the trigger overlay.
+// 2. Nested Tag radius: inset the InputContainer corner by the field border and selection padding.
+//    Tag keeps its default radius when this calc is 0 or negative; see Tag `_theme.scss`.
 
+@use '@tokens' as tokens;
 @use '../../tools/typography';
 @use 'theme';
 
 .UNSTABLE_ComboboxSelection {
+    --#{tokens.$css-variable-prefix}tag-border-radius: calc(
+        var(--#{tokens.$css-variable-prefix}input-container-border-radius) - var(
+                --#{tokens.$css-variable-prefix}input-container-border-width
+            ) -
+            #{theme.$padding-x}
+    ); // 2.
+
     @include typography.from-css-variables($infix: 'input-container');
 
     display: flex;

--- a/packages/web/src/scss/components/UNSTABLE_Picker/_UNSTABLE_PickerSelection.scss
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/_UNSTABLE_PickerSelection.scss
@@ -1,4 +1,6 @@
 // 1. Elevate interactive elements above the trigger overlay.
+// 2. Nested Tag radius: inset the InputContainer corner by the field border and selection padding.
+//    Tag keeps its default radius when this calc is 0 or negative; see Tag `_theme.scss`.
 
 @use '@tokens' as tokens;
 @use '../../tools/form-fields' as form-fields-tools;
@@ -6,6 +8,13 @@
 @use 'theme';
 
 .UNSTABLE_PickerSelection {
+    --#{tokens.$css-variable-prefix}tag-border-radius: calc(
+        var(--#{tokens.$css-variable-prefix}input-container-border-radius) - var(
+                --#{tokens.$css-variable-prefix}input-container-border-width
+            ) -
+            #{theme.$padding-x}
+    ); // 2.
+
     @include typography.from-css-variables($infix: 'input-container');
 
     display: flex;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

Tags inside `UNSTABLE_PickerSelection` were not following the `InputContainer` corner radius, so selected chips looked misaligned with the field. This wires a shared CSS custom property from `InputContainer` into `Tag`, and sets the derived radius in the picker selection so tags inset correctly against the container border and padding.

### Additional context

Stacked on `feat/unstable-split-tag` — review there first if that branch is still open.

### Issue reference

https://jira.almacareer.tech/browse/DS-2710