### PR TITLE
fix(docsite): make root start reliable after branch switch

### DIFF
--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack --port 4321",
     "build": "next build",
-    "start": "next start",
+    "start": "next dev --turbopack --port 4321",
+    "start:prod": "next start --port 4321",
     "lint": "eslint",
     "lint:fix": "yarn lint --fix",
     "test": "npm-run-all --serial lint test:unit:coverage types",

--- a/apps/docsite/project.json
+++ b/apps/docsite/project.json
@@ -12,6 +12,9 @@
     "dev": {
       "dependsOn": ["^build"]
     },
+    "start": {
+      "dependsOn": ["^build", "@alma-oss/spirit-icons:build"]
+    },
     "lint": {
       "dependsOn": ["@alma-oss/spirit-icons:build"]
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

After switching git branches, root `make start` often failed to bring up the local monorepo environment (demo on `:3456`, storybook, docsite). Two things stacked:

1. **Docsite `start` was production-only.** It ran `next start`, which needs a built `.next` directory. After checkout that folder is usually missing or stale, so docsite failed early and took attention away from the rest of the start graph.
2. **Start depends on rebuilt packages.** After a branch switch Nx typically invalidates caches and rebuilds workspace packages before app `start` tasks — notably `@alma-oss/spirit-icons` (demo also copies icons into gitignored `static/assets/icons`). Demo and storybook already waited on `icons:build`; docsite’s `start` did not, so it was out of line with the pipeline that actually has to succeed after a branch change.

This PR makes docsite participate in `make start` the same way the other local apps do:

- `start` / `dev` → `next dev --turbopack` (no `.next` required)
- `start:prod` → `next start` for a local production server after `build`
- `start.dependsOn`: `^build` + `@alma-oss/spirit-icons:build` (aligned with storybook / existing lint gate)
- fixed local port `4321` so docsite does not fight the **cyborg** `:3000` port

Netlify / production deploy is unchanged: it still runs `nx run @alma-oss/spirit-docsite:build` (`next build`), not these start scripts.

### Additional context

- Manually building icons (`yarn workspace @alma-oss/spirit-icons build`) often unblocked `make start` before this change; that matched the hard icons gate on demo/storybook, not a soft cache fallback.
- Unrelated console noise during start (Babel missing `*.js.map` under `packages/web/src`, clean-css warnings on `@starting-style` in `components.css`) can still appear when `^build` runs; not addressed here.

### Issue reference

<!-- none -->
