### PR TITLE
docs(web): add listbox presentation to `UNSTABLE_Picker` #DS-2714

### DIFF
--- a/packages/web/src/scss/components/Dropdown/_DropdownPopover.scss
+++ b/packages/web/src/scss/components/Dropdown/_DropdownPopover.scss
@@ -1,3 +1,5 @@
+// 1. Prevent options with long text from overflowing the popover.
+
 @use 'sass:map';
 @use '@tokens' as tokens;
 @use '../../tools/breakpoint';
@@ -19,11 +21,13 @@
     &[data-spirit-fullwidthmode='mobile-only'] {
         @include breakpoint.down(map.get(theme.$breakpoints, tablet)) {
             width: 100%;
+            min-width: min-content; // 1.
         }
     }
 
     &[data-spirit-fullwidthmode='all'] {
         width: 100%;
+        min-width: min-content; // 1.
     }
 }
 

--- a/packages/web/src/scss/components/UNSTABLE_Combobox/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Combobox/README.md
@@ -610,26 +610,29 @@ input for option navigation; Space and printable characters type into the filter
 
 ### ARIA Attributes
 
-| Attribute                        | Element                | Purpose                                                                |
-| -------------------------------- | ---------------------- | ---------------------------------------------------------------------- |
-| `role="group"`                   | InputContainer         | Groups the selection area and input together                           |
-| `role="group"`                   | Selection inner div    | Initial role when no options are selected                              |
-| `role="grid"`                    | Selection inner div    | Active role when tags are present; enables roving focus across tags    |
-| `role="listbox"` / `role="grid"` | Options Stack          | Options widget (`listbox` default; `grid` for multi-action rows)       |
-| `role="option"` / `role="row"`   | Option item            | One selectable option (listbox or grid)                                |
-| `role="gridcell"`                | Tag / grid option cell | Contains the label and interactive controls (tags; grid options)       |
-| `aria-live="off"`                | Selection inner area   | Announces added tags to screen readers without interrupting            |
-| `role="combobox"`                | Text input             | Identifies the text input as a combobox                                |
-| `aria-haspopup`                  | Text input             | `"listbox"` or `"grid"` matching the options widget; omit for tip-only |
-| `aria-expanded`                  | Text input             | Indicates whether the popover is open                                  |
-| `aria-controls`                  | Text input             | Points to the options widget (omit when there is none)                 |
-| `aria-autocomplete`              | Text input             | Set to `"list"` to indicate filtered suggestions                       |
-| `aria-activedescendant`          | Text input             | Points to the currently active option                                  |
-| `aria-multiselectable`           | Options Stack          | Indicates multiple options can be selected simultaneously              |
-| `aria-selected`                  | Option item            | Marks whether the option is currently selected                         |
-| `aria-describedby`               | Tag / text input       | Links to the removal instruction / helper text / validation message    |
+| Attribute                        | Element                | Purpose                                                                                               |
+| -------------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| `role="group"`                   | InputContainer         | Groups the selection area and input together                                                          |
+| `role="group"`                   | Selection inner div    | Initial role when no options are selected                                                             |
+| `role="grid"`                    | Selection inner div    | Active role when tags are present; enables roving focus across tags                                   |
+| `role="listbox"` / `role="grid"` | Options Stack          | Options widget (`listbox` default; `grid` for multi-action rows)                                      |
+| `role="option"` / `role="row"`   | Option item            | One selectable option (listbox or grid)                                                               |
+| `role="gridcell"`                | Tag / grid option cell | Contains the label and interactive controls (tags; grid options)                                      |
+| `aria-live="off"`                | Selection inner area   | Live region is currently disabled; no change is announced (see [DS-2759][jira-selection-live-region]) |
+| `aria-atomic="false"`            | Selection inner area   | Would announce only the changed node, not the whole region                                            |
+| `aria-relevant="additions"`      | Selection inner area   | Would announce added tags only; removals are left to focus management                                 |
+| `role="combobox"`                | Text input             | Identifies the text input as a combobox                                                               |
+| `aria-haspopup`                  | Text input             | `"listbox"` or `"grid"` matching the options widget; omit for tip-only                                |
+| `aria-expanded`                  | Text input             | Indicates whether the popover is open                                                                 |
+| `aria-controls`                  | Text input             | Points to the options widget (omit when there is none)                                                |
+| `aria-autocomplete`              | Text input             | Set to `"list"` to indicate filtered suggestions                                                      |
+| `aria-activedescendant`          | Text input             | Points to the currently active option                                                                 |
+| `aria-multiselectable`           | Options Stack          | Indicates multiple options can be selected simultaneously                                             |
+| `aria-selected`                  | Option item            | Marks whether the option is currently selected                                                        |
+| `aria-describedby`               | Tag / text input       | Links to the removal instruction / helper text / validation message                                   |
 
 [dropdown]: https://github.com/alma-oss/spirit-design-system/tree/main/packages/web/src/scss/components/Dropdown/README.md
+[jira-selection-live-region]: https://jira.almacareer.tech/browse/DS-2759
 [picker-selection-role]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_Picker/README.md#selection-area-dynamic-role
 [smashing-magazine-placeholder]: https://www.smashingmagazine.com/2018/06/placeholder-attribute/
 [splittag]: https://github.com/alma-oss/spirit-design-system/tree/main/packages/web/src/scss/components/UNSTABLE_SplitTag/README.md

--- a/packages/web/src/scss/components/UNSTABLE_Picker/README.md
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/README.md
@@ -12,7 +12,8 @@ selected values as tags.
 ## Basic Usage
 
 Picker is built on top of the [Dropdown][dropdown] component. It consists of a label, an input container
-displaying chosen options as tags with a trigger button, and optional helper or validation text.
+displaying chosen options as tags with a trigger button, and optional helper or validation text. The
+popover is a `role="dialog"`, so it can hold any content.
 
 ```txt
 Stack                                         space-400
@@ -24,10 +25,12 @@ Stack                                         space-400
 │   │   │   └── [selected]   Tag              role="row" (× N)
 │   │   │       └── role="gridcell"
 │   │   │           ├── tag label
-│   │   │           └── ControlButton        (remove)
+│   │   │           └── ControlButton         (remove)
 │   │   └── UNSTABLE_PickerTrigger            aria-haspopup="dialog"
 │   └── DropdownPopover                       role="dialog"
-│       └── FieldGroup                        (checkboxes or custom content)
+│       ├── [group]     fieldset + legend     role="group" (checkboxes / radios)
+│       ├── [listbox]   option list           role="listbox" · role="option"
+│       └── [free-form] any content           (controls keep their own roles)
 ├── HelperText                                (optional)
 └── ValidationText                            (optional)
 ```
@@ -35,6 +38,22 @@ Stack                                         space-400
 ⚠️ The DropdownPopover is rendered using absolute positioning relative to the trigger. Make sure there is
 enough space below the Picker (or around it, depending on the popover placement) so the popover does not
 overflow its scrollable container or get clipped.
+
+Pick the presentation by what a single option contains; see [decision 013][decision-listbox-grid] for the
+reasoning.
+
+| Presentation                     | Markup                                          | Use when                                                                   |
+| -------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| Group (default)                  | `<fieldset>` and `<legend>` of Checkbox / Radio | options are native form controls, need native submission or richer content |
+| [Listbox](#listbox-presentation) | `role="listbox"` of `role="option"` items       | options are plain selectable labels with no interactive content            |
+| Free-form                        | any content, controls keep their own roles      | the popover is not a uniform list (headings, inputs, an Apply button)      |
+
+ℹ️ `role="grid"` belongs to the selection (tag) area, not to the popover — see
+[Selected Tags](#selected-tags).
+
+The example below uses the default group presentation, with an Apply button as a sibling of the
+`<fieldset>`. The popover needs an accessible name (`aria-label` or `aria-labelledby`) and an `id` the
+trigger points to via `data-spirit-target` and `aria-controls`:
 
 ```html
 <div class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-400);">
@@ -68,7 +87,14 @@ overflow its scrollable container or get clipped.
         </svg>
       </button>
     </div>
-    <div role="dialog" class="DropdownPopover" data-spirit-placement="bottom-start" id="picker-popover">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Languages"
+      class="DropdownPopover placement-bottom-start"
+      data-spirit-placement="bottom-start"
+      id="picker-popover"
+    >
       <fieldset class="border-0">
         <legend class="accessibility-hidden">Language</legend>
         <div class="Flex Flex--vertical Flex--alignmentXLeft" style="--flex-spacing-y: var(--spirit-space-500);">
@@ -83,10 +109,81 @@ overflow its scrollable container or get clipped.
           <!-- More checkboxes… -->
         </div>
       </fieldset>
+      <div class="d-grid mt-600">
+        <button type="button" class="Button Button--primary Button--medium">Apply</button>
+      </div>
     </div>
   </div>
 </div>
 ```
+
+## Listbox Presentation
+
+Inside the popover, set `role="listbox"` on the option list (plus `aria-multiselectable="true"` for multiple
+selection) and `role="option"` with `aria-selected` on each option. Put a decorative check
+(`Icon--selected`, wrapped in `d-none` until selected) in a **trailing** `Item__slot`, placed after
+`Item__content` so unselected options are not indented by an empty leading slot, and give the selected option
+`color-scheme-on-selected-subtle bg-color-scheme`.
+
+Space the options out with `Stack Stack--spacing`, otherwise the focus ring of an option is cropped by the
+background of the selected option next to it.
+
+ℹ️ The listbox must contain **only** options, so place any Apply / close button as a sibling of it. Selection
+lives in `aria-selected` alone, so it does not take part in native form submission — use the default group
+presentation when you need that.
+
+```html
+<!-- The trigger's data-spirit-target and aria-controls point to the popover id. -->
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-label="Languages"
+  class="DropdownPopover placement-bottom-start"
+  data-spirit-placement="bottom-start"
+  id="picker-listbox"
+>
+  <div
+    role="listbox"
+    aria-multiselectable="true"
+    aria-label="Languages"
+    class="Stack Stack--spacing"
+    style="--stack-spacing: var(--spirit-space-500);"
+  >
+    <div
+      role="option"
+      id="picker-listbox-cs"
+      aria-selected="true"
+      tabindex="0"
+      class="Item cursor-pointer color-scheme-on-selected-subtle bg-color-scheme"
+    >
+      <div class="Item__content" role="presentation">
+        <span class="Label element-stretched">Czech</span>
+      </div>
+      <div class="Item__slot" role="presentation">
+        <svg class="Icon Icon--selected" width="20" height="20" aria-hidden="true">
+          <use href="/icons/svg/sprite.svg#check-plain" />
+        </svg>
+      </div>
+    </div>
+    <div role="option" id="picker-listbox-en" aria-selected="false" tabindex="-1" class="Item cursor-pointer">
+      <div class="Item__content" role="presentation">
+        <span class="Label element-stretched">English</span>
+      </div>
+      <div class="Item__slot" role="presentation">
+        <svg class="Icon Icon--selected d-none" width="20" height="20" aria-hidden="true">
+          <use href="/icons/svg/sprite.svg#check-plain" />
+        </svg>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Keyboard (demo JS): a single tab stop (roving `tabindex`), Up/Down between options (clamped at the ends),
+Home/End to first/last, type-ahead by label, and Space/Enter to toggle selection.
+
+ℹ️ This presentation has no React counterpart yet ([DS-2770][jira-listbox-react]), so its demo is excluded
+from visual regression tests, which compare the web and web-react previews against a shared screenshot.
 
 ## Selected Tags
 
@@ -216,7 +313,14 @@ On a **Light on Brand** surface, keep the label on-brand and use **Light Default
       <div role="group" aria-label="Languages" class="InputContainer InputContainer--fill InputContainer--medium">
         <!-- … -->
       </div>
-      <div role="dialog" class="DropdownPopover theme-light-default" id="picker-popover">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Languages"
+        class="DropdownPopover placement-bottom-start theme-light-default"
+        data-spirit-placement="bottom-start"
+        id="picker-popover"
+      >
         <!-- … -->
       </div>
     </div>
@@ -231,10 +335,12 @@ See the [Themes demo][picker-themes-demo].
 Customise the inner `Dropdown` and `DropdownPopover` elements directly using CSS utility classes
 and data attributes. The picker does not set these itself, so any values you add are applied as-is.
 
-- **`DropdownPopover` element** — add a theme utility class (for example `theme-light-default`;
-  this is the default) to control the panel theme.
-- **`data-spirit-placement`** on `.DropdownPopover` — controls where the popover anchors relative
-  to the trigger (for example `bottom-start`).
+- **`DropdownPopover` element** — add a theme utility class (for example `theme-light-default`) to
+  control the panel theme. The picker sets none, so the popover inherits the theme of its surrounding
+  surface; the demos add `theme-light-default` explicitly.
+- **`placement-*` class** on `.DropdownPopover` — controls where the popover anchors relative to the
+  trigger (for example `placement-bottom-start`). Keep the matching `data-spirit-placement` attribute
+  for scripting.
 - **`data-spirit-fullwidthmode`** on `.DropdownPopover` — stretches the popover to the field width
   (`off` · `mobile-only` · `all`).
 
@@ -249,7 +355,9 @@ The following example positions the popover at `bottom-start` and expands it to 
     </div>
     <div
       role="dialog"
-      class="DropdownPopover theme-light-default"
+      aria-modal="true"
+      aria-label="Languages"
+      class="DropdownPopover placement-bottom-start"
       data-spirit-placement="bottom-start"
       data-spirit-fullwidthmode="all"
       id="picker-example"
@@ -428,7 +536,14 @@ inside the selection area (remove buttons) to disable the Picker.
         </svg>
       </button>
     </div>
-    <div role="dialog" class="DropdownPopover" data-spirit-placement="bottom-start" id="picker-disabled">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Languages"
+      class="DropdownPopover placement-bottom-start"
+      data-spirit-placement="bottom-start"
+      id="picker-disabled"
+    >
       <fieldset class="border-0" disabled>
         <legend class="accessibility-hidden">Language</legend>
         <div class="Flex Flex--vertical Flex--alignmentXLeft" style="--flex-spacing-y: var(--spirit-space-500);">
@@ -510,26 +625,18 @@ The selection area (`UNSTABLE_PickerSelection`) uses a dynamic ARIA role:
 - **Selected state** — `role="grid"`: switched by JavaScript when the first tag is added or when the
   picker renders with pre-selected values, and switched back to `group` when the last tag is removed.
 
-[`role="grid"`][mdn-grid-role] was chosen over alternatives because it is the only ARIA role that provides both:
+[`role="grid"`][mdn-grid-role] is used because each tag contains a remove button: `listbox` options cannot
+hold interactive elements and a plain `list` carries no keyboard navigation contract — see
+[decision 013][decision-listbox-grid]. Each tag is structured as a `row` containing a `cell` with the tag
+label and a remove button. A single-column grid is valid and follows the same pattern used by
+[React Aria][react-aria]'s TagGroup.
 
-1. **A keyboard navigation contract** — arrow keys move between items with roving `tabindex`, and only one
-   tag is in the tab order at a time.
-2. **Support for interactive content inside items** — each tag contains a remove button. Roles like `listbox`
-   require `option` children that cannot contain interactive elements. A plain `list` has no keyboard
-   navigation contract.
+### Dropdown Popover: Presentation and Roles
 
-Each tag is structured as a `row` containing a `cell` with the tag label and a remove button.
-A single-column grid is valid and follows the same pattern used by [React Aria][react-aria]'s TagGroup.
-
-### Dropdown Popover: No Listbox Role
-
-The dropdown popover intentionally does **not** use `role="listbox"`. The popover is designed to accept
-any content — Spirit components such as checkboxes, radios, sliders, and text fields. `role="listbox"`
-would be too restrictive: it expects `option` children with `aria-selected`, which conflicts with native
-interactive elements and prevents richer layouts.
-
-The trigger button uses `aria-haspopup="dialog"` to indicate that activating it opens a popup that is not
-a menu or listbox.
+The popover is a `role="dialog"` (the trigger uses `aria-haspopup="dialog"`), so it can hold any content. It
+needs an accessible name via `aria-label` or `aria-labelledby`. The role the **options inside it** carry
+follows from what a single option contains — see [Basic Usage](#basic-usage) for the three presentations and
+[decision 013][decision-listbox-grid] for the reasoning.
 
 ### Dropdown Popover: Required JavaScript Features
 
@@ -537,7 +644,8 @@ The [ARIA dialog role spec][mdn-dialog-role] mandates three JavaScript features.
 `<div role="dialog">`, none of these are provided by the browser and must be implemented explicitly:
 
 1. **Initial focus** — when the popover opens, focus must move to the first focusable element inside
-   it (the first checkbox). This is implemented by listening for the `shown.dropdown` event.
+   it (the first checkbox, or the option carrying `tabindex="0"` in the listbox presentation). This is
+   implemented by listening for the `shown.dropdown` event.
 2. **Focus restoration** — when the popover closes by any means (Escape, click outside, Tab-out),
    focus must return to the trigger button. This is implemented by listening for the `hidden.dropdown`
    event, which fires on every close path.
@@ -583,22 +691,31 @@ Popover API is strongly recommended.
 
 ### ARIA Attributes
 
-| Attribute          | Element           | Purpose                                                                              |
-| ------------------ | ----------------- | ------------------------------------------------------------------------------------ |
-| `role="group"`     | Input container   | Groups the selection area and trigger together                                       |
-| `role="group"`     | Selection area    | Initial role when no options are selected                                            |
-| `role="grid"`      | Selection area    | Active role when options are selected; enables keyboard navigation with roving focus |
-| `role="row"`       | Tag               | Represents a single selected option                                                  |
-| `role="gridcell"`  | Tag inner wrapper | Contains the tag label and remove button                                             |
-| `aria-live`        | Selection area    | Announces changes to selected options                                                |
-| `role="dialog"`    | Dropdown popover  | Marks the popover as a dialog                                                        |
-| `aria-modal`       | Dropdown popover  | Tells screen readers background content is inert while the popover is open           |
-| `aria-haspopup`    | Trigger button    | Indicates the button opens a popup                                                   |
-| `aria-expanded`    | Trigger button    | Indicates whether the popup is open                                                  |
-| `aria-controls`    | Trigger button    | Points to the popup element                                                          |
-| `aria-describedby` | Tag               | Links to the hidden removal instruction                                              |
+| Attribute                   | Element           | Purpose                                                                                               |
+| --------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
+| `role="group"`              | Input container   | Groups the selection area and trigger together                                                        |
+| `role="group"`              | Selection area    | Initial role when no options are selected                                                             |
+| `role="grid"`               | Selection area    | Active role when options are selected; enables keyboard navigation with roving focus                  |
+| `role="row"`                | Tag               | Represents a single selected option                                                                   |
+| `role="gridcell"`           | Tag inner wrapper | Contains the tag label and remove button                                                              |
+| `aria-live="off"`           | Selection area    | Live region is currently disabled; no change is announced (see [DS-2759][jira-selection-live-region]) |
+| `aria-atomic="false"`       | Selection area    | Would announce only the changed node, not the whole region                                            |
+| `aria-relevant="additions"` | Selection area    | Would announce added tags only; removals are left to focus management                                 |
+| `role="dialog"`             | Dropdown popover  | Marks the popover as a dialog                                                                         |
+| `role="listbox"`            | Option list       | Listbox presentation of the popover options                                                           |
+| `aria-multiselectable`      | Option list       | Indicates more than one option can be selected                                                        |
+| `role="option"`             | Option            | Represents a single selectable option                                                                 |
+| `aria-selected`             | Option            | Indicates whether the option is selected                                                              |
+| `aria-modal`                | Dropdown popover  | Tells screen readers background content is inert while the popover is open                            |
+| `aria-haspopup`             | Trigger button    | Indicates the button opens a popup                                                                    |
+| `aria-expanded`             | Trigger button    | Indicates whether the popup is open                                                                   |
+| `aria-controls`             | Trigger button    | Points to the popup element                                                                           |
+| `aria-describedby`          | Tag               | Links to the hidden removal instruction                                                               |
 
+[decision-listbox-grid]: https://github.com/alma-oss/spirit-design-system/blob/main/docs/decisions/013-listbox-vs-grid-for-selectable-options.md
 [dropdown]: https://github.com/alma-oss/spirit-design-system/tree/main/packages/web/src/scss/components/Dropdown/README.md
+[jira-listbox-react]: https://jira.almacareer.tech/browse/DS-2770
+[jira-selection-live-region]: https://jira.almacareer.tech/browse/DS-2759
 [mdn-dialog-role]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/dialog_role
 [mdn-grid-role]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/grid_role
 [picker-themes-demo]: https://github.com/alma-oss/spirit-design-system/blob/main/packages/web/src/scss/components/UNSTABLE_Picker/index.html

--- a/packages/web/src/scss/components/UNSTABLE_Picker/listbox-picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/listbox-picker-demo.mjs
@@ -1,0 +1,179 @@
+// ⚠️ AI-GENERATED CODE, DO NOT COPY-PASTE.
+//
+// Demo interaction for the Picker `listbox` presentation. Options are `role="option"` inside a
+// `role="listbox"`; selection is expressed with `aria-selected` (no native inputs). Keyboard:
+// roving tabindex with Arrow (clamped) / Home / End, Space & Enter to toggle, and type-ahead.
+
+// eslint-disable-next-line import/extensions -- browser ESM (loaded via <script type="module">) requires the extension
+import { createSelectionLabel, createTag, initPopoverBehavior } from './picker-demo.mjs';
+
+const SELECTOR_LISTBOX_PICKER = '[data-spirit-toggle="listbox-picker"]';
+const SELECTOR_DROPDOWN_TRIGGER = '[data-spirit-toggle="dropdown"]';
+const SELECTOR_SELECTION = '[data-spirit-element="selection"]';
+const SELECTOR_LISTBOX = '[role="listbox"]';
+const SELECTOR_OPTION = '[role="option"]';
+const SELECTOR_OPTION_CHECK = '[data-spirit-element="option-check"]';
+const ATTRIBUTE_DATA_TARGET = 'data-spirit-target';
+
+const TYPE_AHEAD_RESET_MS = 500;
+
+const CLASSNAMES_SELECTED = ['color-scheme-on-selected-subtle', 'bg-color-scheme'];
+
+function getOptionLabel(option) {
+  return option.textContent.trim();
+}
+
+function initListboxPicker(dropdownEl) {
+  const selectionEl = dropdownEl.querySelector(SELECTOR_SELECTION);
+  const popoverId = dropdownEl
+    .querySelector(`[${ATTRIBUTE_DATA_TARGET}]`)
+    ?.getAttribute(ATTRIBUTE_DATA_TARGET)
+    ?.slice(1);
+  const popoverEl = popoverId ? document.getElementById(popoverId) : null;
+
+  if (!selectionEl || !popoverEl) return;
+
+  const label = dropdownEl.dataset.pickerLabel || '';
+  const listboxEl = popoverEl.querySelector(SELECTOR_LISTBOX);
+  const isMultiselectable = listboxEl?.getAttribute('aria-multiselectable') === 'true';
+
+  const getOptions = () => Array.from(popoverEl.querySelectorAll(SELECTOR_OPTION));
+  const isSelected = (option) => option.getAttribute('aria-selected') === 'true';
+  const getSelected = () => getOptions().filter(isSelected);
+
+  function setSelected(option, selected) {
+    option.setAttribute('aria-selected', selected ? 'true' : 'false');
+    CLASSNAMES_SELECTED.forEach((className) => option.classList.toggle(className, selected));
+    option.querySelector(SELECTOR_OPTION_CHECK)?.classList.toggle('d-none', !selected);
+  }
+
+  function selectOnly(option) {
+    getOptions().forEach((candidate) => setSelected(candidate, candidate === option));
+  }
+
+  function render() {
+    const selected = getSelected();
+
+    if (selected.length === 0) {
+      selectionEl.setAttribute('role', 'group');
+      selectionEl.textContent = '';
+      selectionEl.appendChild(createSelectionLabel(label));
+
+      return;
+    }
+
+    selectionEl.setAttribute('role', 'grid');
+    selectionEl.textContent = '';
+
+    selected.forEach((option) => {
+      const tag = createTag(
+        getOptionLabel(option),
+        selectionEl,
+        () => {
+          setSelected(option, false);
+          render();
+        },
+        null,
+        '',
+        false,
+      );
+      selectionEl.appendChild(tag);
+    });
+
+    const rows = selectionEl.querySelectorAll('[data-tag-row]');
+
+    if (rows.length > 0) {
+      rows[rows.length - 1].setAttribute('tabindex', '0');
+    }
+  }
+
+  function toggle(option) {
+    if (isMultiselectable) {
+      setSelected(option, !isSelected(option));
+    } else {
+      selectOnly(option);
+    }
+
+    render();
+  }
+
+  function focusOption(option) {
+    getOptions().forEach((candidate) => candidate.setAttribute('tabindex', candidate === option ? '0' : '-1'));
+    option.focus();
+  }
+
+  // Initial roving tab stop: first selected option, else the first option.
+  const initialActive = getSelected()[0] || getOptions()[0];
+  getOptions().forEach((option) => option.setAttribute('tabindex', option === initialActive ? '0' : '-1'));
+
+  let typeAheadBuffer = '';
+  let typeAheadTimeout = null;
+
+  listboxEl?.addEventListener('keydown', (event) => {
+    const options = getOptions();
+    const current = document.activeElement?.closest(SELECTOR_OPTION);
+    const index = options.indexOf(current);
+
+    if (index < 0) return;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        focusOption(options[Math.min(index + 1, options.length - 1)]);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        focusOption(options[Math.max(index - 1, 0)]);
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusOption(options[0]);
+        break;
+      case 'End':
+        event.preventDefault();
+        focusOption(options[options.length - 1]);
+        break;
+      case ' ':
+      case 'Enter':
+        event.preventDefault();
+        toggle(current);
+        break;
+      default:
+        if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          if (typeAheadTimeout) clearTimeout(typeAheadTimeout);
+          typeAheadBuffer += event.key.toLowerCase();
+          typeAheadTimeout = setTimeout(() => {
+            typeAheadBuffer = '';
+          }, TYPE_AHEAD_RESET_MS);
+
+          const match = options.find((option) => getOptionLabel(option).toLowerCase().startsWith(typeAheadBuffer));
+
+          if (match) focusOption(match);
+        }
+        break;
+    }
+  });
+
+  getOptions().forEach((option) => {
+    option.addEventListener('click', () => toggle(option));
+    option.addEventListener('focus', () => {
+      getOptions().forEach((candidate) => candidate.setAttribute('tabindex', candidate === option ? '0' : '-1'));
+    });
+  });
+
+  render();
+}
+
+export function initListboxPickers() {
+  document.querySelectorAll(SELECTOR_LISTBOX_PICKER).forEach((dropdownEl) => {
+    initListboxPicker(dropdownEl);
+
+    const triggerEl = dropdownEl.querySelector(SELECTOR_DROPDOWN_TRIGGER);
+    const popoverId = triggerEl?.getAttribute(ATTRIBUTE_DATA_TARGET)?.slice(1);
+    const popoverEl = popoverId ? document.getElementById(popoverId) : null;
+
+    if (triggerEl && popoverEl) {
+      initPopoverBehavior(triggerEl, popoverEl);
+    }
+  });
+}

--- a/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/picker-demo.mjs
@@ -35,7 +35,7 @@ const TAG_SIZES = {
   medium: { tagSizeClass: 'Tag--medium', controlButtonSizeClass: 'ControlButton--xsmall' },
 };
 
-function createSelectionLabel(text) {
+export function createSelectionLabel(text) {
   const template = document.getElementById(ID_SELECTION_LABEL_TEMPLATE);
   const label = template.content.cloneNode(true);
 
@@ -50,7 +50,7 @@ function getCheckboxLabel(checkbox) {
   return label ? label.textContent.trim() : '';
 }
 
-function createTag(tagLabel, selectionEl, onClose, sizeConfig, tagClass, isDisabled) {
+export function createTag(tagLabel, selectionEl, onClose, sizeConfig, tagClass, isDisabled) {
   const tag = document.getElementById(ID_TAG_TEMPLATE).content.cloneNode(true);
   const row = tag.querySelector(SELECTOR_TAG_ROW);
 

--- a/packages/web/src/scss/components/UNSTABLE_Picker/preview.html
+++ b/packages/web/src/scss/components/UNSTABLE_Picker/preview.html
@@ -1,10 +1,12 @@
 <!-- Picker JavaScript interaction DEMO -->
 <script type="module">
   import { initPickers } from './picker-demo.mjs';
+  import { initListboxPickers } from './listbox-picker-demo.mjs';
   import { initSalaryPicker } from './salary-picker-demo.mjs';
   import { initPublicationTimePicker } from './publication-time-picker-demo.mjs';
 
   initPickers();
+  initListboxPickers();
   initSalaryPicker();
   initPublicationTimePicker();
 
@@ -125,7 +127,6 @@
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -138,6 +139,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-lang"
@@ -257,14 +259,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-lang-pre"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-lang-pre"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -277,6 +278,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-lang-pre"
@@ -366,6 +368,319 @@
 
 </section>
 
+<!-- Hidden from visual tests: no React counterpart yet (DS-2770), and both previews share one screenshot. -->
+<section class="py-900 py-tablet-1000 hide-from-visual-tests">
+
+  <div class="Container">
+
+    <h2 class="docs-Heading">Listbox presentation</h2>
+
+    <!-- Options are role="option" inside role="listbox"; selection uses aria-selected (no inputs). -->
+
+    <div class="docs-Stack docs-Stack--start">
+
+      <div class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-400);">
+
+        <span class="Label">Languages</span>
+
+        <div
+          class="Dropdown"
+          data-spirit-toggle="listbox-picker"
+          data-picker-label="Languages"
+        >
+
+          <div
+            role="group"
+            aria-label="Languages"
+            class="InputContainer InputContainer--fill InputContainer--medium"
+          >
+
+            <div
+              role="group"
+              tabindex="-1"
+              aria-atomic="false"
+              aria-label="Selected languages"
+              aria-live="off"
+              aria-relevant="additions"
+              id="picker-listbox-selection"
+              class="UNSTABLE_PickerSelection"
+              data-spirit-element="selection"
+            >
+              <span
+                class="UNSTABLE_PickerSelection__empty"
+                data-spirit-element="selection-label"
+                aria-hidden="true"
+              >Languages</span>
+            </div>
+
+            <button
+              data-spirit-toggle="dropdown"
+              data-spirit-target="#picker-listbox"
+              class="UNSTABLE_PickerTrigger"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="picker-listbox"
+            >
+              <span class="accessibility-hidden">Add</span>
+              <svg
+                class="Icon"
+                width="20"
+                height="20"
+                aria-hidden="true"
+              >
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </button>
+          </div>
+
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Languages"
+            class="DropdownPopover placement-bottom-start theme-light-default"
+            data-spirit-placement="bottom-start"
+            id="picker-listbox"
+          >
+
+            <div
+              role="listbox"
+              aria-multiselectable="true"
+              aria-label="Languages"
+              class="Stack Stack--spacing"
+              style="--stack-spacing: var(--spirit-space-500);"
+            >
+
+              <div
+                role="option"
+                id="picker-listbox-cs"
+                aria-selected="false"
+                tabindex="0"
+                class="Item cursor-pointer"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Czech</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected d-none"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+              <div
+                role="option"
+                id="picker-listbox-dk"
+                aria-selected="false"
+                tabindex="-1"
+                class="Item cursor-pointer"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Danish</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected d-none"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+              <div
+                role="option"
+                id="picker-listbox-kl"
+                aria-selected="false"
+                tabindex="-1"
+                class="Item cursor-pointer"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Greenlandic</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected d-none"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+      <div class="Stack Stack--spacing" style="--stack-spacing: var(--spirit-space-400);">
+
+        <span class="Label">Languages</span>
+
+        <div
+          class="Dropdown"
+          data-spirit-toggle="listbox-picker"
+          data-picker-label="Languages"
+        >
+
+          <div
+            role="group"
+            aria-label="Languages"
+            class="InputContainer InputContainer--fill InputContainer--medium"
+          >
+
+            <div
+              role="group"
+              tabindex="-1"
+              aria-atomic="false"
+              aria-label="Selected languages"
+              aria-live="off"
+              aria-relevant="additions"
+              id="picker-listbox-pre-selection"
+              class="UNSTABLE_PickerSelection"
+              data-spirit-element="selection"
+            >
+              <span
+                class="UNSTABLE_PickerSelection__empty"
+                data-spirit-element="selection-label"
+                aria-hidden="true"
+              >Languages</span>
+            </div>
+
+            <button
+              data-spirit-toggle="dropdown"
+              data-spirit-target="#picker-listbox-pre"
+              class="UNSTABLE_PickerTrigger"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="picker-listbox-pre"
+            >
+              <span class="accessibility-hidden">Add</span>
+              <svg
+                class="Icon"
+                width="20"
+                height="20"
+                aria-hidden="true"
+              >
+                <use href="/assets/icons/svg/sprite.svg#chevron-down" />
+              </svg>
+            </button>
+          </div>
+
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Languages"
+            class="DropdownPopover placement-bottom-start theme-light-default"
+            data-spirit-placement="bottom-start"
+            id="picker-listbox-pre"
+          >
+
+            <div
+              role="listbox"
+              aria-multiselectable="true"
+              aria-label="Languages"
+              class="Stack Stack--spacing"
+              style="--stack-spacing: var(--spirit-space-500);"
+            >
+
+              <div
+                role="option"
+                id="picker-listbox-pre-cs"
+                aria-selected="true"
+                tabindex="0"
+                class="Item cursor-pointer color-scheme-on-selected-subtle bg-color-scheme"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Czech</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+              <div
+                role="option"
+                id="picker-listbox-pre-dk"
+                aria-selected="true"
+                tabindex="-1"
+                class="Item cursor-pointer color-scheme-on-selected-subtle bg-color-scheme"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Danish</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+              <div
+                role="option"
+                id="picker-listbox-pre-kl"
+                aria-selected="false"
+                tabindex="-1"
+                class="Item cursor-pointer"
+              >
+                <div class="Item__content" role="presentation">
+                  <span class="Label element-stretched">Greenlandic</span>
+                </div>
+                <div class="Item__slot" role="presentation">
+                  <svg
+                    class="Icon Icon--selected d-none"
+                    data-spirit-element="option-check"
+                    width="20"
+                    height="20"
+                    aria-hidden="true"
+                  >
+                    <use href="/assets/icons/svg/sprite.svg#check-plain" />
+                  </svg>
+                </div>
+              </div>
+
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+
+</section>
+
 <section class="py-900 py-tablet-1000">
 
   <div class="Container">
@@ -421,7 +736,6 @@
                 <span class="accessibility-hidden">Add</span>
                 <svg
                   class="Icon"
-                  viewBox="0 0 24 24"
                   width="20"
                   height="20"
                   aria-hidden="true"
@@ -434,6 +748,7 @@
             <div
               role="dialog"
               aria-modal="true"
+              aria-label="Languages"
               class="DropdownPopover placement-bottom-start theme-light-default"
               data-spirit-placement="bottom-start"
               data-spirit-fullwidthmode="all"
@@ -576,7 +891,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -589,6 +903,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-fill-bg-primary-popover"
@@ -708,7 +1023,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -721,6 +1035,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-outline-bg-primary-popover"
@@ -846,7 +1161,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -859,6 +1173,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-fill-bg-secondary-popover"
@@ -978,7 +1293,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -991,6 +1305,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-outline-bg-secondary-popover"
@@ -1116,7 +1431,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -1129,6 +1443,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-fill-bg-tertiary-popover"
@@ -1248,7 +1563,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -1261,6 +1575,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-outline-bg-tertiary-popover"
@@ -1386,7 +1701,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -1399,6 +1713,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-fill-theme-light-on-brand-bg-primary-popover"
@@ -1519,7 +1834,6 @@
                   <span class="accessibility-hidden">Add</span>
                   <svg
                     class="Icon"
-                    viewBox="0 0 24 24"
                     width="20"
                     height="20"
                     aria-hidden="true"
@@ -1532,6 +1846,7 @@
               <div
                 role="dialog"
                 aria-modal="true"
+                aria-label="Languages"
                 class="DropdownPopover placement-bottom-start theme-light-default"
                 data-spirit-placement="bottom-start"
                 id="picker-variant-outline-theme-light-on-brand-bg-primary-popover"
@@ -1613,7 +1928,7 @@
         </div>
       </div>
 
-    </div> </div>
+    </div>
 
   </div>
 
@@ -1675,7 +1990,6 @@
                 <span class="accessibility-hidden">Add</span>
                 <svg
                   class="Icon"
-                  viewBox="0 0 24 24"
                   width="20"
                   height="20"
                   aria-hidden="true"
@@ -1688,6 +2002,7 @@
             <div
               role="dialog"
               aria-modal="true"
+              aria-label="Languages"
               class="DropdownPopover placement-bottom-start theme-light-default"
               data-spirit-placement="bottom-start"
               id="picker-small"
@@ -1808,7 +2123,6 @@
                 <span class="accessibility-hidden">Add</span>
                 <svg
                   class="Icon"
-                  viewBox="0 0 24 24"
                   width="20"
                   height="20"
                   aria-hidden="true"
@@ -1821,6 +2135,7 @@
             <div
               role="dialog"
               aria-modal="true"
+              aria-label="Languages"
               class="DropdownPopover placement-bottom-start theme-light-default"
               data-spirit-placement="bottom-start"
               id="picker-medium"
@@ -1941,7 +2256,6 @@
                 <span class="accessibility-hidden">Add</span>
                 <svg
                   class="Icon"
-                  viewBox="0 0 24 24"
                   width="20"
                   height="20"
                   aria-hidden="true"
@@ -1954,6 +2268,7 @@
             <div
               role="dialog"
               aria-modal="true"
+              aria-label="Languages"
               class="DropdownPopover placement-bottom-start theme-light-default"
               data-spirit-placement="bottom-start"
               id="picker-large"
@@ -2081,14 +2396,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-lang2"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-lang2"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2101,6 +2415,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-lang2"
@@ -2234,14 +2549,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-hidden-label"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-hidden-label"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2254,6 +2568,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-hidden-label"
@@ -2387,14 +2702,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-required"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-required"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2407,6 +2721,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-required"
@@ -2541,14 +2856,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-helper"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-helper"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2561,6 +2875,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-helper"
@@ -2698,14 +3013,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-danger"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-danger"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2718,6 +3032,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-danger"
@@ -2840,14 +3155,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-warning"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-warning"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -2860,6 +3174,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-warning"
@@ -2983,14 +3298,13 @@
               data-spirit-toggle="dropdown"
               data-spirit-target="#picker-success"
               class="UNSTABLE_PickerTrigger"
-              aria-haspopup="listbox"
+              aria-haspopup="dialog"
               aria-expanded="false"
               aria-controls="picker-success"
             >
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -3003,6 +3317,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-success"
@@ -3159,6 +3474,8 @@
 
           <div
             role="dialog"
+            aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-disabled"
@@ -3300,6 +3617,8 @@
 
           <div
             role="dialog"
+            aria-modal="true"
+            aria-label="Languages"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-disabled-pre"
@@ -3442,7 +3761,6 @@
               <span class="accessibility-hidden">Edit</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -3455,6 +3773,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Salary"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-salary"
@@ -3603,7 +3922,6 @@
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -3616,6 +3934,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Publication time"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="demo-picker-publication-time"
@@ -3768,7 +4087,6 @@
               <span class="accessibility-hidden">Add</span>
               <svg
                 class="Icon"
-                viewBox="0 0 24 24"
                 width="20"
                 height="20"
                 aria-hidden="true"
@@ -3781,6 +4099,7 @@
           <div
             role="dialog"
             aria-modal="true"
+            aria-label="Employment type"
             class="DropdownPopover placement-bottom-start theme-light-default"
             data-spirit-placement="bottom-start"
             id="picker-job-filters"


### PR DESCRIPTION
## Description

Adds a listbox-presentation demo and docs to the vanilla `UNSTABLE_Picker`: a `role="listbox"` option list in the preview and a demo-only `listbox-picker-demo.mjs` (roving `tabindex`, Arrow/Home/End, type-ahead, `aria-selected` toggle).

It also generalizes the docs so the popover is no longer documented as a `FieldGroup` slot. Basic Usage now branches the component schema into the three presentations — group (`fieldset`), listbox, and free-form — with a table saying which to pick, and the default example gains an Apply button next to the `<fieldset>` to show why the popover is more than an option list. All the *why* now lives in decision 013 (#2844) rather than being restated in three places in the README.

Every `DropdownPopover` in the README and the preview is unified on one shape: `role="dialog"`, `aria-modal`, an accessible name, the `placement-bottom-start` class with a matching `data-spirit-placement`, and an `id` the trigger points to. That closed real gaps — no popover had an accessible name, the two disabled demo pickers were missing `aria-modal`, and the README examples had the placement attribute without the class that actually does the positioning. Also corrects pre-existing demo markup: `aria-haspopup="dialog"` on triggers (was `listbox`) and dropped `viewBox` from icons.

Follows the role decision in the ADR. Mirrors the web-react listbox demo 1:1.

### Additional context

- 📚 Stacked on #2844 (ADR) — review/merge that first; this PR targets its branch. The web-react PR (#2874) is stacked on top of this one.
- Replaces #2846, which GitHub auto-closed as merged when the stack was reordered.
- ℹ️ The `placement-*` class is what positions the popover (the Dropdown JS never reads `data-spirit-placement` — only Tooltip does), so the docs now name the class and keep the attribute for scripting.
- JS interaction is demo-only and not part of Spirit.

### Issue reference

JIRA: https://jira.almacareer.tech/browse/DS-2714
