### PR TITLE
test(web-react): add iconNamePropTest for components with icon-name props

### DIFF
--- a/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
+++ b/packages/web-react/src/components/Alert/__tests__/Alert.test.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
 import React from 'react';
 import {
   ariaAttributesTest,
@@ -7,15 +6,15 @@ import {
   colorSchemeSubtleTest,
   elementTypePropsTest,
   emotionColorPropsTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import { EmotionColors } from '../../../constants';
 import { getColorSchemeClassName } from '../../../utils';
 import Alert from '../Alert';
-
-jest.mock('../../../hooks/useIcon');
 
 describe('Alert', () => {
   classNamePrefixProviderTest(Alert, 'Alert');
@@ -33,6 +32,8 @@ describe('Alert', () => {
   ariaAttributesTest(Alert);
 
   elementTypePropsTest(Alert);
+
+  iconNamePropTest(Alert);
 
   it('should have default classname', () => {
     const dom = render(<Alert />);

--- a/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
+++ b/packages/web-react/src/components/Breadcrumbs/__tests__/BreadcrumbsItem.test.tsx
@@ -1,16 +1,15 @@
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
 import React from 'react';
 import {
   ariaAttributesTest,
   classNamePrefixProviderTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import BreadcrumbsItem from '../BreadcrumbsItem';
-
-jest.mock('../../../hooks/useIcon');
 
 describe('BreadcrumbsItem', () => {
   classNamePrefixProviderTest(BreadcrumbsItem, 'd-none');
@@ -23,6 +22,10 @@ describe('BreadcrumbsItem', () => {
   validHtmlAttributesTest(BreadcrumbsItem);
 
   ariaAttributesTest(BreadcrumbsItem);
+
+  iconNamePropTest(BreadcrumbsItem, 'iconNameEnd');
+
+  iconNamePropTest(BreadcrumbsItem, 'iconNameStart', { isGoBackOnly: true });
 
   describe('BreadcrumbsItem with go back title', () => {
     const BreadcrumbsItemGoBack = () => (

--- a/packages/web-react/src/components/File/__tests__/File.test.tsx
+++ b/packages/web-react/src/components/File/__tests__/File.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import {
   ariaAttributesTest,
@@ -7,13 +7,13 @@ import {
   formFieldHelperTextContextPropsTest,
   formFieldLabelContextPropsTest,
   formFieldValidationTextContextPropsTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import File from '../File';
-
-jest.mock('../../../hooks/useIcon');
 
 const defaultProps = {
   id: 'unstable-file-1',
@@ -71,6 +71,8 @@ describe('File', () => {
   formFieldValidationTextContextPropsTest({
     renderComponent: (props) => <File {...defaultProps} {...props} />,
   });
+
+  iconNamePropTest(File, 'iconName', defaultProps);
 
   it('should render dismiss button with accessible name', () => {
     render(

--- a/packages/web-react/src/components/FileUpload/__tests__/FileUpload.test.tsx
+++ b/packages/web-react/src/components/FileUpload/__tests__/FileUpload.test.tsx
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { createEvent, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { renderToString } from 'react-dom/server';
@@ -9,13 +9,13 @@ import {
   formFieldHelperTextContextPropsTest,
   formFieldLabelContextPropsTest,
   formFieldValidationTextContextPropsTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import FileUpload from '../FileUpload';
-
-jest.mock('../../../hooks/useIcon');
 
 const defaultProps = { id: 'file-uploader' };
 const defaultPropsWithInput = { id: 'file-upload-input', name: 'file-upload-input', label: 'upload' };
@@ -50,6 +50,8 @@ describe('FileUpload', () => {
       renderComponent: (props) => <FileUpload {...defaultPropsWithInput} {...props} />,
       labelText: 'upload',
     });
+
+    iconNamePropTest(FileUpload, 'iconName', defaultPropsWithInput);
 
     it('should have drag-and-drop class in Client component', () => {
       const { container } = render(<FileUpload {...defaultPropsWithInput} data-testid="test" />);

--- a/packages/web-react/src/components/IconBox/__tests__/IconBox.test.tsx
+++ b/packages/web-react/src/components/IconBox/__tests__/IconBox.test.tsx
@@ -1,20 +1,20 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import {
   ariaAttributesTest,
   elementTypePropsTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import { EmotionColors } from '../../../constants';
 import type { IconBoxColorsType, IconBoxShapeType, SizeExtendedDictionaryType } from '../../../types';
 import { pxToRem } from '../../../utils';
 import { IconBoxShapesRadii, IconBoxSizes } from '../constants';
 import IconBox from '../IconBox';
-
-jest.mock('../../../hooks/useIcon');
 
 const sizeTestCasesProvider = Object.entries(IconBoxSizes).map(([size, { iconSize, padding }]) => ({
   size,
@@ -55,6 +55,8 @@ describe('IconBox', () => {
   ariaAttributesTest(IconBox);
 
   elementTypePropsTest(IconBox);
+
+  iconNamePropTest(IconBox);
 
   it('should render the icon', () => {
     render(<IconBox iconName="check" data-testid="IconBox" />);

--- a/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
+++ b/packages/web-react/src/components/Toast/__tests__/ToastBar.test.tsx
@@ -1,17 +1,17 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import {
   ariaAttributesTest,
   classNamePrefixProviderTest,
+  iconNamePropTest,
   restPropsTest,
   stylePropsTest,
   validHtmlAttributesTest,
 } from '@local/tests';
+import { renderWithIcons as render } from '@local/tests/testUtils/testIcons';
 import { getColorSchemeClassName } from '../../../utils';
 import ToastBar from '../ToastBar';
-
-jest.mock('../../../hooks/useIcon');
 
 describe('ToastBar', () => {
   classNamePrefixProviderTest((props) => <ToastBar {...props} id="test" />, 'ToastBar');
@@ -23,6 +23,8 @@ describe('ToastBar', () => {
   validHtmlAttributesTest(ToastBar);
 
   ariaAttributesTest(ToastBar);
+
+  iconNamePropTest(ToastBar, 'iconName', { id: 'toast-icon-test' });
 
   it('should not render', () => {
     const dom = render(<ToastBar isOpen={false} id="test" />);

--- a/packages/web-react/tests/providerTests/iconNamePropTest.tsx
+++ b/packages/web-react/tests/providerTests/iconNamePropTest.tsx
@@ -1,0 +1,40 @@
+import { waitFor } from '@testing-library/react';
+import React, { type ComponentType } from 'react';
+import { TestIconsProvider, renderWithIcons } from '../testUtils/testIcons';
+
+const FIRST_ICON = 'icon-name-prop-test-first';
+const SECOND_ICON = 'icon-name-prop-test-second';
+
+/**
+ * Tests that a component with an icon-name prop renders the requested icon,
+ * and that changing the prop's value changes which icon is rendered.
+ *
+ * @param {ComponentType<any>} Component - the React component under test.
+ * @param {string} propName - default 'iconName'; the prop that selects the icon.
+ * @param {Record<string, unknown>} requiredProps - extra props needed to make the icon
+ *   actually render (e.g. conditionally-rendered icons).
+ */
+export const iconNamePropTest = (
+  Component: ComponentType<any>,
+  propName: string = 'iconName',
+  requiredProps: Record<string, unknown> = {},
+) => {
+  it(`should change the rendered icon when the "${propName}" prop changes`, async () => {
+    const dom = renderWithIcons(<Component {...requiredProps} {...{ [propName]: FIRST_ICON }} />);
+
+    await waitFor(() => {
+      expect(dom.container.querySelector(`[data-icon-name="${FIRST_ICON}"]`)).toBeInTheDocument();
+    });
+
+    dom.rerender(
+      <TestIconsProvider>
+        <Component {...requiredProps} {...{ [propName]: SECOND_ICON }} />
+      </TestIconsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(dom.container.querySelector(`[data-icon-name="${SECOND_ICON}"]`)).toBeInTheDocument();
+      expect(dom.container.querySelector(`[data-icon-name="${FIRST_ICON}"]`)).not.toBeInTheDocument();
+    });
+  });
+};

--- a/packages/web-react/tests/providerTests/index.ts
+++ b/packages/web-react/tests/providerTests/index.ts
@@ -4,6 +4,7 @@ export * from './colorSchemePropsTest';
 export * from './dictionaryPropsTest';
 export * from './elementTypePropsTest';
 export * from './formFieldContextPropsTest';
+export * from './iconNamePropTest';
 export * from './itemPropsTest';
 export * from './loadingPropsTest';
 export * from './requiredPropsTest';

--- a/packages/web-react/tests/testUtils/testIcons.tsx
+++ b/packages/web-react/tests/testUtils/testIcons.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable react-refresh/only-export-components -- Test util exports a fixture and a render helper alongside a component */
+import { type RenderOptions, type RenderResult, render } from '@testing-library/react';
+import React, { type ReactElement, type ReactNode } from 'react';
+import { IconsProvider } from '../../src/context';
+
+// Resolves any icon name on demand, so consumers don't need to enumerate every
+// literal icon name (e.g. 'check', 'edit', 'close', 'chevron-left') used across test files.
+export const testIcons: Record<string, string> = new Proxy(
+  {},
+  {
+    get: (_target, iconName: string) => `<path data-testid="test-icon" data-icon-name="${String(iconName)}"></path>`,
+  },
+);
+
+export const TestIconsProvider = ({ children }: { children: ReactNode }): ReactElement => (
+  <IconsProvider value={testIcons}>{children}</IconsProvider>
+);
+
+/**
+ * Drop-in replacement for RTL's `render` that resolves icons via `testIcons` instead of requiring `jest.mock('.../hooks/useIcon')`.
+ *
+ * @param {ReactElement} ui - the element to render.
+ * @param {Omit<RenderOptions, 'wrapper'>} options - RTL render options, forwarded as-is; `wrapper` is reserved for `TestIconsProvider`.
+ */
+export const renderWithIcons = (ui: ReactElement, options: Omit<RenderOptions, 'wrapper'> = {}): RenderResult =>
+  render(ui, { ...options, wrapper: TestIconsProvider });


### PR DESCRIPTION
## Description

DS-771 asked for a shared prop test that verifies a component's icon actually changes when its icon-name prop changes, but no such helper existed — the 6 components with an icon-name prop (`Alert`, `IconBox`, `File`, `FileUpload`, `ToastBar`, `BreadcrumbsItem`) only asserted that *an* icon rendered, never that the *correct* one did. The blocker was that `Icon` renders via `useIcon(name)`, which every consuming test file short-circuited with `jest.mock('.../hooks/useIcon')` — so icon identity was never observable in the DOM.

Adds `iconNamePropTest`, a shared helper (in the same family as `elementTypePropsTest`, `stylePropsTest`, etc.) that renders through a real `IconsProvider` backed by a `testIcons` fixture (a `Proxy` that resolves any icon name to identifiable markup), then asserts the rendered icon changes when the prop's value changes. Wired it into all 6 target components, replacing their `jest.mock('.../hooks/useIcon')` with the real-provider fixture via a shared `renderWithIcons` helper.

### Additional context

`BreadcrumbsItem` needed two calls (`iconNameStart`/`iconNameEnd`) since it has two icon props with different conditions to actually render (`isGoBackOnly` gates the start icon). `FileUpload`'s icon only renders once an input exists (`name` prop set) and it's not compact, so that call passes the required extra props.

### Issue reference

https://jira.almacareer.tech/browse/DS-771