### PR TITLE
fix(web): apply aria-selected only to role=tab elements in Tabs #DS-2678

### DIFF
--- a/packages/web/src/js/Tabs.ts
+++ b/packages/web/src/js/Tabs.ts
@@ -67,8 +67,10 @@ class Tabs extends BaseComponent {
     element.classList.add(CLASS_NAME_ACTIVE);
     this.activate(getElementFromSelector(element));
 
-    element.removeAttribute('tabindex');
-    element.setAttribute('aria-selected', 'true');
+    if (element.getAttribute('role') === 'tab') {
+      element.removeAttribute('tabindex');
+      element.setAttribute('aria-selected', 'true');
+    }
     EventHandler.trigger(element, EVENT_SHOWN, {
       relatedTarget: relatedElem,
     });
@@ -82,8 +84,10 @@ class Tabs extends BaseComponent {
     element.classList.remove(CLASS_NAME_ACTIVE);
     this.deactivate(getElementFromSelector(element));
 
-    element.setAttribute('aria-selected', 'false');
-    element.setAttribute('tabindex', '-1');
+    if (element.getAttribute('role') === 'tab') {
+      element.setAttribute('aria-selected', 'false');
+      element.setAttribute('tabindex', '-1');
+    }
     EventHandler.trigger(element, EVENT_HIDDEN, { relatedTarget: relatedElem });
   }
 

--- a/packages/web/src/js/__tests__/Tabs.test.ts
+++ b/packages/web/src/js/__tests__/Tabs.test.ts
@@ -186,6 +186,32 @@ describe('Tabs', () => {
       await firstTabs.show();
     });
 
+    it('should not set aria-selected or mutate tabindex on role=tabpanel when activating a tab', async () => {
+      fixtureEl.innerHTML = `
+          <ul class="Tabs" role="tablist">
+            <li class="Tabs__item" role="presentation"><button type="button" data-spirit-target="#home" class="Tabs__link is-selected" role="tab" aria-selected="true">Home</button></li>
+            <li class="Tabs__item" role="presentation"><button type="button" id="trigger-profile" data-spirit-target="#profile" class="Tabs__link" role="tab">Profile</button></li>
+          </ul>
+          <div class="Tabs-content">
+            <div class="TabsPane is-selected" id="home" role="tabpanel"></div>
+            <div class="TabsPane" id="profile" role="tabpanel"></div>
+          </div>
+        `;
+
+      const profileTriggerEl = fixtureEl.querySelector('#trigger-profile') as HTMLElement;
+      const profilePanelEl = fixtureEl.querySelector('#profile') as HTMLElement;
+      const homePanelEl = fixtureEl.querySelector('#home') as HTMLElement;
+      const tab = new Tabs(profileTriggerEl);
+
+      await tab.show();
+
+      expect(profileTriggerEl.getAttribute('aria-selected')).toBe('true');
+      expect(profilePanelEl.hasAttribute('aria-selected')).toBe(false);
+      expect(homePanelEl.hasAttribute('aria-selected')).toBe(false);
+      expect(profilePanelEl.hasAttribute('tabindex')).toBe(false);
+      expect(homePanelEl.hasAttribute('tabindex')).toBe(false);
+    });
+
     it('should handle removed tabs', async () => {
       fixtureEl.innerHTML = `
           <ul class="Tabs" role="tablist">


### PR DESCRIPTION
The `activate()` and `deactivate()` methods were called recursively on the target `tabpanel`, causing `aria-selected` to be set on `role="tabpanel"` which does not support that attribute. Guard now checks `role="tab"` before mutating `aria-selected` and `tabindex`.

<!-- Thank you for contributing! -->

## Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### Issue reference

https://jira.almacareer.tech/browse/DS-2678

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->

<!--

### Before submitting the PR, please make sure you do the following

- Read the [Contributing Guidelines](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md).
- Follow the [PR Title/Commit Message Convention](https://github.com/alma-oss/spirit-design-system/blob/main/CONTRIBUTING.md#commit-conventions).
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
