### PR TITLE
docs(web-react): add draft CV builder edit screen example page #DS-2746

### DIFF
--- a/packages/web-react/docs/stories/examples/CvEditorPersonalDetails.stories.tsx
+++ b/packages/web-react/docs/stories/examples/CvEditorPersonalDetails.stories.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import {
+  ActionGroup,
+  Box,
+  Breadcrumbs,
+  Button,
+  Checkbox,
+  Grid,
+  GridItem,
+  Heading,
+  Section,
+  Stack,
+  TextField,
+} from '../../../src/components';
+
+export default {
+  title: 'Examples/Pages',
+  parameters: { layout: 'fullscreen' },
+};
+
+export const CvEditorPersonalDetails = () => {
+  const [showTitle, setShowTitle] = useState(false);
+
+  return (
+    <>
+      <Section elementType="div" backgroundColor="secondary" containerProps={{ size: 'small' }} paddingTop="space-1000">
+        <Stack spacing="space-1000">
+          <Breadcrumbs
+            goBackTitle="Zpět"
+            items={[{ title: 'Můj Jobs.cz', url: '#' }, { title: 'Životopis', url: '#' }, { title: 'Osobní údaje' }]}
+          />
+          <Heading
+            id="cv-personal-details-heading"
+            elementType="h1"
+            size="small"
+            fontWeight="semibold"
+            marginBottom="space-0"
+          >
+            Osobní údaje
+          </Heading>
+        </Stack>
+      </Section>
+      <Section elementType="div" size="small" backgroundColor="secondary" containerProps={{ size: 'small' }}>
+        <Stack spacing="space-1000">
+          <form aria-labelledby="cv-personal-details-heading" method="post" action="#">
+            {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
+                and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
+            <Box
+              backgroundColor="primary"
+              borderColor="basic"
+              borderRadius="400"
+              borderWidth="100"
+              padding="space-900"
+              marginBottom={{ mobile: 'space-900', tablet: 'space-1000' }}
+            >
+              {/* TODO [DS-2775]: `TextField` renders an internal `Stack` (`display: grid`). As a direct `Grid`
+                  child it gets vertically stretched to match the tallest sibling. Each field must be wrapped
+                  in `GridItem` to contain the stretch. */}
+              <Grid cols={{ mobile: 1, tablet: 2 }} spacing={{ mobile: 'space-700', tablet: 'space-900' }}>
+                <GridItem>
+                  <TextField id="personal-details-first-name" label="Jméno" autoComplete="given-name" isRequired />
+                </GridItem>
+                <GridItem>
+                  <TextField id="personal-details-last-name" label="Příjmení" autoComplete="family-name" isRequired />
+                </GridItem>
+                <GridItem columnEnd={{ mobile: 'span 1', tablet: 'span 2' }}>
+                  <Checkbox
+                    id="personal-details-show-title"
+                    name="showTitle"
+                    label="Uvádět titul u jména"
+                    aria-expanded={showTitle}
+                    {...(showTitle && {
+                      'aria-controls': 'personal-details-title-before personal-details-title-after',
+                    })}
+                    isChecked={showTitle}
+                    onChange={() => setShowTitle(!showTitle)}
+                  />
+                </GridItem>
+                {showTitle && (
+                  <>
+                    <GridItem>
+                      <TextField
+                        id="personal-details-title-before"
+                        label="Titul před jménem"
+                        autoComplete="honorific-prefix"
+                      />
+                    </GridItem>
+                    <GridItem>
+                      <TextField
+                        id="personal-details-title-after"
+                        label="Titul za jménem"
+                        autoComplete="honorific-suffix"
+                      />
+                    </GridItem>
+                  </>
+                )}
+                <GridItem>
+                  <TextField id="personal-details-email" label="E-mail" type="email" autoComplete="email" isRequired />
+                </GridItem>
+                <GridItem>
+                  <TextField
+                    id="personal-details-phone"
+                    label="Telefon"
+                    type="tel"
+                    autoComplete="tel"
+                    helperText="Číslo zadejte včetně předvolby (např. +420111222333)"
+                  />
+                </GridItem>
+                <GridItem>
+                  <TextField id="personal-details-city" label="Město / Obec" autoComplete="address-level2" />
+                </GridItem>
+              </Grid>
+            </Box>
+            <ActionGroup
+              direction={{ mobile: 'vertical', tablet: 'horizontal-reversed' }}
+              alignmentX={{ mobile: 'stretch', tablet: 'left' }}
+              spacing="space-600"
+            >
+              <Button type="submit">Uložit</Button>
+              <Button color="secondary">Zrušit</Button>
+            </ActionGroup>
+          </form>
+        </Stack>
+      </Section>
+    </>
+  );
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The personal-details **edit** screen from the [New Jobs.cz Handoff Figma file][figma] needed a real render before hand-off, to see how much of it Spirit's components already cover. This adds it as a throwaway `Examples/Pages` Storybook story composed only of Spirit components — nothing in `src/`, so it is a deletable file rather than shipped code. Opening as a draft: the point is to review the composition and the DS gaps it surfaced, not to merge it. Follows the same approach as #2879 (CV editor overview).

### Page structure

```
CvEditorPersonalDetails
├─ Section₁ (elementType: div, bg: secondary, paddingTop: 1000, container: small)
│  └─ Stack (spacing: 1000)
│     ├─ Breadcrumbs (goBackTitle: "Zpět")
│     └─ Heading (h1, id: cv-personal-details-heading, size: small, fontWeight: semibold) "Osobní údaje"
└─ Section₂ (elementType: div, bg: secondary, size: small, container: small)
   └─ Stack (spacing: 1000)
      └─ form (aria-labelledby → h1 in Section₁, method: post)
         ├─ Box (bg: primary, border: basic, borderWidth: 100, radius: 400, padding: 900,
         │        marginBottom: { mobile: 900, tablet: 1000 })
         │  └─ Grid (cols: { mobile: 1, tablet: 2 }, spacing: { mobile: 700, tablet: 900 })
         │     ├─ GridItem → TextField "Jméno" (required, autoComplete: given-name)
         │     ├─ GridItem → TextField "Příjmení" (required, autoComplete: family-name)
         │     ├─ GridItem (columnEnd: { mobile: span 1, tablet: span 2 })
         │     │  └─ Checkbox "Uvádět titul u jména"
         │     │           aria-expanded, aria-controls (conditional)
         │     ├─ GridItem → TextField "Titul před jménem" (autoComplete: honorific-prefix)   ┐ conditional:
         │     ├─ GridItem → TextField "Titul za jménem" (autoComplete: honorific-suffix)     ┘ shown when checkbox is checked
         │     ├─ GridItem → TextField "E-mail" (required, type: email, autoComplete: email)
         │     ├─ GridItem → TextField "Telefon" (type: tel, autoComplete: tel)
         │     └─ GridItem → TextField "Město / Obec" (autoComplete: address-level2)
         └─ ActionGroup (direction: { mobile: vertical, tablet: horizontal-reversed },
                         alignmentX: { mobile: stretch, tablet: left }, spacing: 600)
            ├─ Button type="submit" "Uložit"      ← first in DOM, right visually on tablet
            └─ Button color="secondary" "Zrušit"  ← second in DOM, left visually on tablet
```

### Accessibility tree

```
<body>
├─ div                                    — role: generic (Section₁ header band)
│  ├─ nav "Breadcrumb"                    — landmark: navigation
│  │  └─ list
│  │     ├─ listitem → link "Můj Jobs.cz"
│  │     ├─ listitem → link "Životopis"   ← mobile: preceded by link "Zpět" / Životopis
│  │     └─ listitem → "Osobní údaje"    — plain text, aria-current="page" (no href)
│  └─ h1 "Osobní údaje"                  — id: cv-personal-details-heading
└─ div                                    — role: generic (Section₂ form band)
   └─ form "Osobní údaje"                — landmark: form (named via aria-labelledby → h1 in Section₁)
      ├─ label + input "Jméno *"         — required, autoComplete: given-name
      ├─ label + input "Příjmení *"      — required, autoComplete: family-name
      ├─ label + checkbox "Uvádět titul u jména"
      │           aria-expanded: false → true on check
      │           aria-controls (conditional — absent when title fields are not in DOM)
      ├─ label + input "Titul před jménem"   ┐  conditional:
      ├─ label + input "Titul za jménem"     ┘  only in DOM when checkbox is checked
      ├─ label + input "E-mail *"        — required, type: email, autoComplete: email
      ├─ label + input "Telefon"         — type: tel, autoComplete: tel
      │           + helper text "Číslo zadejte včetně předvolby…" (via aria-describedby)
      ├─ label + input "Město / Obec"   — autoComplete: address-level2
      └─ div                             — role: generic (ActionGroup)
         ├─ button "Uložit" (type: submit) — first in DOM, rightmost visually on tablet
         └─ button "Zrušit"              — second in DOM, leftmost visually on tablet
```

- **`<form>` is a landmark** because it carries `aria-labelledby` — a named `<form>` exposes the `form` role to the accessibility tree, making it reachable by landmark navigation. An unnamed `<form>` does not. The form wraps both the styled field card and the action buttons, so `type="submit"` on "Uložit" correctly targets this form.
- **`Breadcrumbs` uses `aria-label="Breadcrumb"`** — hardcoded English regardless of locale, the same issue noted in [DS-2747](https://jira.almacareer.tech/browse/DS-2747) from #2879.
- **`ActionGroup` renders as `<div>`** — no landmark role, so the button group is not directly reachable by landmark navigation. Buttons inside remain individually focusable.
- **DOM order and visual order diverge for buttons on tablet**: `direction="horizontal-reversed"` (`flex-direction: row-reverse`) places "Uložit" visually on the right while keeping it first in Tab order. This is intentional — the submit action receives keyboard priority (Enter activates it), and reversal is purely cosmetic.
- **`aria-controls` is conditional**: the attribute is only present on the checkbox when the title `TextField`s are in the DOM. When the checkbox is unchecked the fields are removed from the DOM, so omitting `aria-controls` avoids an invalid ARIA reference; `aria-expanded` alone signals the collapsed state.

### Additional context

Figma node: [3827-4404 (checkbox unchecked)][figma] · [3827-4428 (checkbox checked)][figma-checked]

Storybook: `Examples/Pages` → `Cv Editor Personal Details`

The Figma library belongs to a different product built on the same Spirit token system, so pixel-for-pixel parity is not expected — everything renders with this repo's own Spirit token values.

### Design considerations

ℹ️ For the Spirit Design System team.

Genuine gaps the design ran into, worth a look:

- The card container has `shadow-100` in the Figma design. `Box` has no `boxShadow` prop and there is no shadow utility class in the `web` package, so the shadow is intentionally omitted in this story. The only current workaround is `UNSAFE_style`.

### Developer considerations

ℹ️ For the Spirit Design System team.

TODOs left in the story, filed under the [DS-2758](https://jira.almacareer.tech/browse/DS-2758) "CV editor follow-up" epic — 🚨 bug, ✨ feature:

- ✨ [DS-2774](https://jira.almacareer.tech/browse/DS-2774) — `Box` has no `boxShadow` prop and there is no shadow utility class in `web`
- 🚨 [DS-2775](https://jira.almacareer.tech/browse/DS-2775) — `TextField` and other components with an internal `Stack` get vertically stretched when used as direct `Grid` children

### Issue reference

https://jira.almacareer.tech/browse/DS-2746

<details>
<summary>Retrospective: lessons from converting this design with the Figma-to-Spirit skill</summary>

**Lessons learned**

- The skill correctly mapped layout, spacing, and token values. Every correction made was either a deprecated-prop substitution, a missing semantic wrapper, or an accessibility concern — none of which the skill currently covers.
- `emphasis="semibold"` was generated for `Heading` instead of `fontWeight="semibold"`. The skill's Heading reference predates the DS-2725 deprecation and was never updated.
- `Flex` was generated for the submit/cancel button pair instead of `ActionGroup`. The skill has no guidance on when to prefer `ActionGroup` over `Flex`, nor on the DOM-first-submit UX pattern.
- `TextField` components were placed as direct `Grid` children. `TextField` internally renders a `Stack` with `display: grid`; when it is itself a grid item of an outer `Grid`, the outer grid stretches it vertically to match the tallest sibling in the row. Wrapping each field in `GridItem` isolates the stretch. The skill has no mention of this.
- The Grid was generated with a fixed `cols={2}` and separate `spacingX`/`spacingY`. Spirit's Grid accepts responsive breakpoint objects; the skill should default to responsive values for any multi-column form layout.
- The Figma had two variant nodes (unchecked / checked checkbox state) revealing a conditional disclosure pattern. The skill generated a static render with no `useState`; the disclosure had to be scaffolded by hand.
- The form element was generated as `Box elementType="form"` wrapping only the field card, leaving the submit button outside the `<form>`. The correct structure is a native `<form>` wrapping both the field card and the `ActionGroup`.

**Accessibility gaps not caught by the skill**

- No `autoComplete` attributes on personal-data fields (WCAG 1.3.5).
- No `aria-labelledby` on the `<form>` element to create a named form landmark.
- `aria-controls` was added pointing to element IDs that only exist conditionally; the skill has no guidance on conditional `aria-controls`.

**Skill improvements identified**

| # | Gap | Skill |
|---|---|---|
| 1 | Keep `fontWeight` / `emphasis` in sync with deprecations | `figma-to-spirit` |
| 2 | Prefer `ActionGroup` over `Flex` for button groups; document DOM-first-submit pattern | `figma-to-spirit` |
| 3 | Wrap form fields in `GridItem` inside `Grid` to prevent vertical stretch | `figma-to-spirit` |
| 4 | Generate responsive `cols` and `spacing` objects by default | `figma-to-spirit` |
| 5 | Detect disclosure patterns from multiple Figma variants; scaffold `useState` | `figma-to-spirit` |
| 6 | Native `<form>` should wrap both field card and action buttons | `figma-to-spirit` |
| 7 | Add `autoComplete` to personal-data fields (WCAG 1.3.5) | both |
| 8 | Add `aria-labelledby` on `<form>`, `id` on page heading | `accessibility` |
| 9 | `aria-controls` must be conditional when target is conditionally rendered | `accessibility` |

</details>

[figma]: https://www.figma.com/design/8ufvVYLhsORI03CFpweNHk/New-Jobs.cz-Handoff?node-id=3827-4404
[figma-checked]: https://www.figma.com/design/8ufvVYLhsORI03CFpweNHk/New-Jobs.cz-Handoff?node-id=3827-4428