### PR TITLE
docs(storybook): move `UNSTABLE_Table` stories under experimental

### DIFF
--- a/packages/web-react/src/components/UNSTABLE_Table/stories/UNSTABLE_Table.stories.tsx
+++ b/packages/web-react/src/components/UNSTABLE_Table/stories/UNSTABLE_Table.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import UNSTABLE_Table from '../UNSTABLE_Table';
 
 const meta: Meta<typeof UNSTABLE_Table> = {
-  title: 'Components/UNSTABLE_Table',
+  title: 'Experimental/UNSTABLE_Table',
   component: UNSTABLE_Table,
   parameters: {
     docs: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

`UNSTABLE_Table` was listed under the Storybook `Components` group while other experimental components live under `Experimental`, which made the sidebar inconsistent. Moving the story title to `Experimental/UNSTABLE_Table` aligns it with `UNSTABLE_Combobox`, `UNSTABLE_Picker`, and the rest.

<img width="305" height="203" alt="image" src="https://github.com/user-attachments/assets/de7b991d-71a6-4984-ae9c-81fc4a346378" />


### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->