### PR TITLE
feat(web): expose basic and subtle background colors in color schemes #DS-2402

### DIFF
--- a/docs/decisions/015-color-scheme-intensity-exposure.md
+++ b/docs/decisions/015-color-scheme-intensity-exposure.md
@@ -1,0 +1,70 @@
+# Color Scheme Intensity Exposure
+
+Date: 2026-09-03
+
+Status: accepted
+
+Amends: [012](012-color-schemes.md)
+
+## Context
+
+[Color Schemes](012-color-schemes.md) established that a `color-scheme-on-<category>-<intensity>` class pairs one
+background intensity with the contrasting content intensity, and exposes that single pair as `--spirit-local-color`,
+`--spirit-local-border-color`, and `--spirit-local-background-color`.
+
+That pairing covers components whose colored region is visually flat. It does not cover components whose colored
+region combines both intensities at once — a subtle surface with a basic-colored element drawn on top of it, for
+example. With only the picked intensity exposed, such a component has to either nest a second color scheme class on
+the inner element, or reach for the raw design tokens and re-implement the whole category matrix in its own CSS.
+Both defeat the purpose of color schemes: one class per colored region, tokens resolved centrally.
+
+Border colors already had this problem and had already been solved ad hoc — the subtle border color is exposed
+regardless of the intensity picked, because the dynamic color helpers always want the subtle border so that it stands
+out on a basic background.
+
+## Decision
+
+1. **Both intensities are always exposed.** In addition to the paired properties from
+   [Color Schemes](012-color-schemes.md), every `color-scheme-on-*` class sets both intensities of the background
+   and content colors as local custom properties, regardless of which intensity the class name picks:
+   - `--spirit-local-background-color-basic` and `--spirit-local-background-color-subtle`
+   - `--spirit-local-color-basic` and `--spirit-local-color-subtle`
+
+   The paired properties keep the semantics they have in [Color Schemes](012-color-schemes.md):
+   `--spirit-local-color` and `--spirit-local-background-color` continue to resolve to the pair implied by the
+   `<intensity>` in the class name. The new properties are additive; nothing about the existing contract changes.
+
+2. **Sass accessors mirror the custom properties.** The `tools/color-scheme` module exposes `color-basic()`,
+   `color-subtle()`, `background-color-basic()`, and `background-color-subtle()` alongside the existing `color()` and
+   `background-color()`, each taking an optional fallback. Component CSS reads the intensities through these rather
+   than writing the custom property names by hand.
+
+3. **Categories without a pair reuse what they have.** The `disabled` category has no background pair of its own, so
+   the disabled foreground stands in for the basic background: it is the color of a filled element sitting on a
+   disabled surface. It likewise has a single content color, which therefore serves as both content intensities.
+   This keeps `color-scheme-on-disabled` substitutable for any other scheme class without a component having to
+   special-case it.
+
+## Consequences
+
+### Single Class for the Whole Colored Region
+
+A component that combines both intensities within one colored region can be colored by one scheme class on its root,
+with the inner parts reading the intensity they need. No nested scheme classes, no per-category CSS in the component.
+
+### Intensities Are Available Before They Are Consumed
+
+The properties are emitted for every category whether or not any component reads them today. This is deliberate: the
+generator has no way to know which intensities a consumer needs, and making the set conditional would reintroduce the
+per-component branching that color schemes exist to remove.
+
+### Larger Generated CSS
+
+Each scheme class emits four more declarations. The cost is bounded — it scales with the number of categories, not
+with the number of components — and is paid back as soon as it removes one component's hand-rolled color matrix.
+
+### Substitutability Is a Constraint on New Categories
+
+Because components may now read any intensity from any scheme class, a new category has to provide all of them. Where
+tokens do not exist for one, an explicit stand-in must be chosen, as done for `disabled`. A category that silently
+omits an intensity would render a component that reads it uncolored.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -60,6 +60,12 @@ In practice, this means you choose one surface class and Spirit keeps text, back
    `color-scheme-on-accent-01-subtle`, or `color-scheme-on-disabled`). Each one sets **local** custom properties for content, border, and background (with the
    Spirit CSS variable prefix), for example `--spirit-local-color` and `--spirit-local-background-color`.
 
+   ℹ️ Every surface class also exposes both intensities of the background and content colors regardless of which variant you picked
+   (`--spirit-local-background-color-basic`, `--spirit-local-background-color-subtle`, `--spirit-local-color-basic`, and `--spirit-local-color-subtle`), so a
+   single surface class can color a component that combines them, for example a subtle surface carrying a basic-colored indicator. For
+   `color-scheme-on-disabled`, the basic background is the disabled foreground — the color of a filled element sitting on a disabled surface — and its single
+   content color serves as both content intensities.
+
 2. **Utilities or Components** — On the same element (or an ancestor that already has a surface class), use utilities that read those locals: `bg-color-scheme`,
    `text-color-scheme`, and `border-color-scheme` so backgrounds, text, and borders stay on-palette without listing every token. See the [dynamic color helper demo][dynamic-color-demo] for examples.
    Or read the color scheme directly in the component CSS classes (for example `Pill`).

--- a/packages/web/src/scss/tools/__tests__/_color-scheme.test.scss
+++ b/packages/web/src/scss/tools/__tests__/_color-scheme.test.scss
@@ -9,65 +9,97 @@
             (
                 emotion-danger-basic: (
                     color: var(--spirit-color-emotion-danger-content-subtle),
+                    color-basic: var(--spirit-color-emotion-danger-content-basic),
+                    color-subtle: var(--spirit-color-emotion-danger-content-subtle),
                     border-color: var(--spirit-color-emotion-danger-border-basic),
                     border-color-subtle: var(--spirit-color-emotion-danger-border-subtle),
                     background-color: var(--spirit-color-emotion-danger-background-basic),
+                    background-color-basic: var(--spirit-color-emotion-danger-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-danger-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-danger-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-danger-state-active),
                 ),
                 emotion-danger-subtle: (
                     color: var(--spirit-color-emotion-danger-content-basic),
+                    color-basic: var(--spirit-color-emotion-danger-content-basic),
+                    color-subtle: var(--spirit-color-emotion-danger-content-subtle),
                     border-color: var(--spirit-color-emotion-danger-border-subtle),
                     border-color-subtle: var(--spirit-color-emotion-danger-border-subtle),
                     background-color: var(--spirit-color-emotion-danger-background-subtle),
+                    background-color-basic: var(--spirit-color-emotion-danger-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-danger-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-danger-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-danger-state-active),
                 ),
                 emotion-informative-basic: (
                     color: var(--spirit-color-emotion-informative-content-subtle),
+                    color-basic: var(--spirit-color-emotion-informative-content-basic),
+                    color-subtle: var(--spirit-color-emotion-informative-content-subtle),
                     border-color: var(--spirit-color-emotion-informative-border-basic),
                     border-color-subtle: var(--spirit-color-emotion-informative-border-subtle),
                     background-color: var(--spirit-color-emotion-informative-background-basic),
+                    background-color-basic: var(--spirit-color-emotion-informative-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-informative-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-informative-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-informative-state-active),
                 ),
                 emotion-informative-subtle: (
                     color: var(--spirit-color-emotion-informative-content-basic),
+                    color-basic: var(--spirit-color-emotion-informative-content-basic),
+                    color-subtle: var(--spirit-color-emotion-informative-content-subtle),
                     border-color: var(--spirit-color-emotion-informative-border-subtle),
                     border-color-subtle: var(--spirit-color-emotion-informative-border-subtle),
                     background-color: var(--spirit-color-emotion-informative-background-subtle),
+                    background-color-basic: var(--spirit-color-emotion-informative-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-informative-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-informative-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-informative-state-active),
                 ),
                 emotion-success-basic: (
                     color: var(--spirit-color-emotion-success-content-subtle),
+                    color-basic: var(--spirit-color-emotion-success-content-basic),
+                    color-subtle: var(--spirit-color-emotion-success-content-subtle),
                     border-color: var(--spirit-color-emotion-success-border-basic),
                     border-color-subtle: var(--spirit-color-emotion-success-border-subtle),
                     background-color: var(--spirit-color-emotion-success-background-basic),
+                    background-color-basic: var(--spirit-color-emotion-success-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-success-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-success-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-success-state-active),
                 ),
                 emotion-success-subtle: (
                     color: var(--spirit-color-emotion-success-content-basic),
+                    color-basic: var(--spirit-color-emotion-success-content-basic),
+                    color-subtle: var(--spirit-color-emotion-success-content-subtle),
                     border-color: var(--spirit-color-emotion-success-border-subtle),
                     border-color-subtle: var(--spirit-color-emotion-success-border-subtle),
                     background-color: var(--spirit-color-emotion-success-background-subtle),
+                    background-color-basic: var(--spirit-color-emotion-success-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-success-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-success-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-success-state-active),
                 ),
                 emotion-warning-basic: (
                     color: var(--spirit-color-emotion-warning-content-subtle),
+                    color-basic: var(--spirit-color-emotion-warning-content-basic),
+                    color-subtle: var(--spirit-color-emotion-warning-content-subtle),
                     border-color: var(--spirit-color-emotion-warning-border-basic),
                     border-color-subtle: var(--spirit-color-emotion-warning-border-subtle),
                     background-color: var(--spirit-color-emotion-warning-background-basic),
+                    background-color-basic: var(--spirit-color-emotion-warning-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-warning-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-warning-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-warning-state-active),
                 ),
                 emotion-warning-subtle: (
                     color: var(--spirit-color-emotion-warning-content-basic),
+                    color-basic: var(--spirit-color-emotion-warning-content-basic),
+                    color-subtle: var(--spirit-color-emotion-warning-content-subtle),
                     border-color: var(--spirit-color-emotion-warning-border-subtle),
                     border-color-subtle: var(--spirit-color-emotion-warning-border-subtle),
                     background-color: var(--spirit-color-emotion-warning-background-subtle),
+                    background-color-basic: var(--spirit-color-emotion-warning-background-basic),
+                    background-color-subtle: var(--spirit-color-emotion-warning-background-subtle),
                     background-color-state-hover: var(--spirit-color-emotion-warning-state-hover),
                     background-color-state-active: var(--spirit-color-emotion-warning-state-active),
                 ),
@@ -94,8 +126,12 @@
                     (
                         fixture-basic: (
                             color: #fff,
+                            color-basic: #111,
+                            color-subtle: #fff,
                             border-color: #0f0,
                             background-color: #f00,
+                            background-color-basic: #f00,
+                            background-color-subtle: #fee,
                         ),
                     )
                 );
@@ -104,9 +140,136 @@
             @include test.expect() {
                 .color-scheme-on-fixture-basic {
                     --spirit-local-color: #fff;
+                    --spirit-local-color-basic: #111;
+                    --spirit-local-color-subtle: #fff;
                     --spirit-local-border-color: #0f0;
                     --spirit-local-background-color: #f00;
+                    --spirit-local-background-color-basic: #f00;
+                    --spirit-local-background-color-subtle: #fee;
                 }
+            }
+        }
+    }
+}
+
+@include test.describe('color-scheme-values function') {
+    @include test.it('should expose the disabled foreground as the basic background') {
+        $values: map.get(color-scheme.color-scheme-values(), 'disabled');
+
+        @include test.assert-equal(map.get($values, 'background-color-basic'), var(--spirit-color-disabled-foreground));
+        @include test.assert-equal(
+            map.get($values, 'background-color-subtle'),
+            var(--spirit-color-disabled-background)
+        );
+    }
+
+    @include test.it('should use the single disabled content color for both content intensities') {
+        $values: map.get(color-scheme.color-scheme-values(), 'disabled');
+
+        @include test.assert-equal(map.get($values, 'color-basic'), var(--spirit-color-disabled-content));
+        @include test.assert-equal(map.get($values, 'color-subtle'), var(--spirit-color-disabled-content));
+    }
+}
+
+@include test.describe('color-basic function') {
+    @include test.it('should return the local basic content color variable when no fallback is given') {
+        @include test.assert() {
+            @include test.output() {
+                color: color-scheme.color-basic();
+            }
+
+            @include test.expect() {
+                color: var(--spirit-local-color-basic);
+            }
+        }
+    }
+
+    @include test.it('should include the fallback value when given') {
+        @include test.assert() {
+            @include test.output() {
+                color: color-scheme.color-basic(#111);
+            }
+
+            @include test.expect() {
+                color: var(--spirit-local-color-basic, #111);
+            }
+        }
+    }
+}
+
+@include test.describe('color-subtle function') {
+    @include test.it('should return the local subtle content color variable when no fallback is given') {
+        @include test.assert() {
+            @include test.output() {
+                color: color-scheme.color-subtle();
+            }
+
+            @include test.expect() {
+                color: var(--spirit-local-color-subtle);
+            }
+        }
+    }
+
+    @include test.it('should include the fallback value when given') {
+        @include test.assert() {
+            @include test.output() {
+                color: color-scheme.color-subtle(#eee);
+            }
+
+            @include test.expect() {
+                color: var(--spirit-local-color-subtle, #eee);
+            }
+        }
+    }
+}
+
+@include test.describe('background-color-basic function') {
+    @include test.it('should return the local basic background color variable when no fallback is given') {
+        @include test.assert() {
+            @include test.output() {
+                background-color: color-scheme.background-color-basic();
+            }
+
+            @include test.expect() {
+                background-color: var(--spirit-local-background-color-basic);
+            }
+        }
+    }
+
+    @include test.it('should include the fallback value when given') {
+        @include test.assert() {
+            @include test.output() {
+                background-color: color-scheme.background-color-basic(#f00);
+            }
+
+            @include test.expect() {
+                background-color: var(--spirit-local-background-color-basic, #f00);
+            }
+        }
+    }
+}
+
+@include test.describe('background-color-subtle function') {
+    @include test.it('should return the local subtle background color variable when no fallback is given') {
+        @include test.assert() {
+            @include test.output() {
+                background-color: color-scheme.background-color-subtle();
+            }
+
+            @include test.expect() {
+                background-color: var(--spirit-local-background-color-subtle);
+            }
+        }
+    }
+
+    @include test.it('should include the fallback value when given') {
+        @include test.assert() {
+            @include test.output() {
+                background-color: color-scheme.background-color-subtle(#0f0);
+            }
+
+            @include test.expect() {
+                background-color: var(--spirit-local-background-color-subtle, #0f0);
             }
         }
     }

--- a/packages/web/src/scss/tools/_color-scheme.scss
+++ b/packages/web/src/scss/tools/_color-scheme.scss
@@ -1,8 +1,14 @@
 // Generates `.color-scheme-on-*` classes: `--local-color`, `--local-border-color`, and `--local-background-color`.
+// Basic backgrounds are paired with subtle text colors and vice versa.
 // Pairing logic and token references match the former utilities map (see color-scheme-values).
 //
 // 1. The subtle border color is exposed regardless of the variant because the dynamic color helpers always use the
 //    subtle border, so it stands out on a basic background (see tools/dynamic-colors).
+// 2. Both intensities of the background and content colors are exposed regardless of the variant so that a single
+//    scheme class can color a component that combines them, e.g. a subtle surface carrying a basic-colored indicator.
+// 3. The disabled scheme has no background pair of its own, so the disabled foreground stands in for the basic
+//    background: it is the color of a filled element sitting on a disabled surface. It has a single content color,
+//    which therefore serves as both content intensities.
 
 @use '@tokens' as tokens;
 @use 'sass:map';
@@ -16,7 +22,6 @@ $_accent-tokens-key: 'accent-colors';
 $_emotion-prefix: 'emotion-';
 $_emotion-tokens-key: 'emotion-colors';
 
-// Basic backgrounds are paired with subtle text colors and vice versa.
 @function generate-color-scheme-map($tokens-group, $prefix: '') {
     $result: ();
     $token-map: tokens-tools.get-variable-if-exists($tokens-group, null);
@@ -44,10 +49,13 @@ $_emotion-tokens-key: 'emotion-colors';
                 string.unquote($name),
                 (
                     color: $content-subtle,
+                    color-basic: $content-basic,
+                    color-subtle: $content-subtle,
                     border-color: $border-basic,
-                    // 1.
                     border-color-subtle: $border-subtle,
                     background-color: $background-basic,
+                    background-color-basic: $background-basic,
+                    background-color-subtle: $background-subtle,
                     background-color-state-hover: $state-hover,
                     background-color-state-active: $state-active,
                 )
@@ -61,10 +69,13 @@ $_emotion-tokens-key: 'emotion-colors';
                 string.unquote($name),
                 (
                     color: $content-basic,
+                    color-basic: $content-basic,
+                    color-subtle: $content-subtle,
                     border-color: $border-subtle,
-                    // 1.
                     border-color-subtle: $border-subtle,
                     background-color: $background-subtle,
+                    background-color-basic: $background-basic,
+                    background-color-subtle: $background-subtle,
                     background-color-state-hover: $state-hover,
                     background-color-state-active: $state-active,
                 )
@@ -82,42 +93,58 @@ $_emotion-tokens-key: 'emotion-colors';
         (
             disabled: (
                 color: tokens.$disabled-content,
+                color-basic: tokens.$disabled-content,
+                color-subtle: tokens.$disabled-content,
                 border-color: tokens.$disabled-border,
                 background-color: tokens.$disabled-background,
+                background-color-basic: tokens.$disabled-foreground,
+                background-color-subtle: tokens.$disabled-background,
             ),
             neutral-basic: (
                 color: tokens.$neutral-content-subtle,
+                color-basic: tokens.$neutral-content-basic,
+                color-subtle: tokens.$neutral-content-subtle,
                 border-color: tokens.$neutral-border-basic,
-                // 1.
                 border-color-subtle: tokens.$neutral-border-subtle,
                 background-color: tokens.$neutral-background-basic,
+                background-color-basic: tokens.$neutral-background-basic,
+                background-color-subtle: tokens.$neutral-background-subtle,
                 background-color-state-hover: tokens.$neutral-state-hover,
                 background-color-state-active: tokens.$neutral-state-active,
             ),
             neutral-subtle: (
                 color: tokens.$neutral-content-basic,
+                color-basic: tokens.$neutral-content-basic,
+                color-subtle: tokens.$neutral-content-subtle,
                 border-color: tokens.$neutral-border-subtle,
-                // 1.
                 border-color-subtle: tokens.$neutral-border-subtle,
                 background-color: tokens.$neutral-background-subtle,
+                background-color-basic: tokens.$neutral-background-basic,
+                background-color-subtle: tokens.$neutral-background-subtle,
                 background-color-state-hover: tokens.$neutral-state-hover,
                 background-color-state-active: tokens.$neutral-state-active,
             ),
             selected-basic: (
                 color: tokens.$selected-content-subtle,
+                color-basic: tokens.$selected-content-basic,
+                color-subtle: tokens.$selected-content-subtle,
                 border-color: tokens.$selected-border-basic,
-                // 1.
                 border-color-subtle: tokens.$selected-border-subtle,
                 background-color: tokens.$selected-background-basic,
+                background-color-basic: tokens.$selected-background-basic,
+                background-color-subtle: tokens.$selected-background-subtle,
                 background-color-state-hover: tokens.$selected-state-hover,
                 background-color-state-active: tokens.$selected-state-active,
             ),
             selected-subtle: (
                 color: tokens.$selected-content-basic,
+                color-basic: tokens.$selected-content-basic,
+                color-subtle: tokens.$selected-content-subtle,
                 border-color: tokens.$selected-border-subtle,
-                // 1.
                 border-color-subtle: tokens.$selected-border-subtle,
                 background-color: tokens.$selected-background-subtle,
+                background-color-basic: tokens.$selected-background-basic,
+                background-color-subtle: tokens.$selected-background-subtle,
                 background-color-state-hover: tokens.$selected-state-hover,
                 background-color-state-active: tokens.$selected-state-active,
             ),
@@ -131,6 +158,22 @@ $_emotion-tokens-key: 'emotion-colors';
     }
 
     @return var(--#{tokens.$css-variable-prefix}local-color, $fallback);
+}
+
+@function color-basic($fallback: null) {
+    @if not $fallback {
+        @return var(--#{tokens.$css-variable-prefix}local-color-basic);
+    }
+
+    @return var(--#{tokens.$css-variable-prefix}local-color-basic, $fallback);
+}
+
+@function color-subtle($fallback: null) {
+    @if not $fallback {
+        @return var(--#{tokens.$css-variable-prefix}local-color-subtle);
+    }
+
+    @return var(--#{tokens.$css-variable-prefix}local-color-subtle, $fallback);
 }
 
 @function border-color($fallback: null) {
@@ -155,6 +198,22 @@ $_emotion-tokens-key: 'emotion-colors';
     }
 
     @return var(--#{tokens.$css-variable-prefix}local-background-color, $fallback);
+}
+
+@function background-color-basic($fallback: null) {
+    @if not $fallback {
+        @return var(--#{tokens.$css-variable-prefix}local-background-color-basic);
+    }
+
+    @return var(--#{tokens.$css-variable-prefix}local-background-color-basic, $fallback);
+}
+
+@function background-color-subtle($fallback: null) {
+    @if not $fallback {
+        @return var(--#{tokens.$css-variable-prefix}local-background-color-subtle);
+    }
+
+    @return var(--#{tokens.$css-variable-prefix}local-background-color-subtle, $fallback);
 }
 
 @function background-color-state-hover($fallback: null) {
@@ -184,15 +243,29 @@ $_emotion-tokens-key: 'emotion-colors';
 @mixin emit-color-scheme-classes($values, $class-prefix: 'color-scheme-on') {
     @each $key, $pair in $values {
         $color: map.get($pair, color);
+        $color-basic: map.get($pair, color-basic); // 2.
+        $color-subtle: map.get($pair, color-subtle); // 2.
         $border-color: map.get($pair, border-color);
         $border-color-subtle: map.get($pair, border-color-subtle); // 1.
         $background-color: map.get($pair, background-color);
+        $background-color-basic: map.get($pair, background-color-basic); // 2.
+        $background-color-subtle: map.get($pair, background-color-subtle); // 2.
         $background-color-state-hover: map.get($pair, background-color-state-hover);
         $background-color-state-active: map.get($pair, background-color-state-active);
 
         .#{$class-prefix}-#{$key} {
             @if $color {
                 --#{tokens.$css-variable-prefix}local-color: #{$color};
+            }
+
+            // 2.
+            @if $color-basic {
+                --#{tokens.$css-variable-prefix}local-color-basic: #{$color-basic};
+            }
+
+            // 2.
+            @if $color-subtle {
+                --#{tokens.$css-variable-prefix}local-color-subtle: #{$color-subtle};
             }
 
             @if $border-color {
@@ -206,6 +279,16 @@ $_emotion-tokens-key: 'emotion-colors';
 
             @if $background-color {
                 --#{tokens.$css-variable-prefix}local-background-color: #{$background-color};
+            }
+
+            // 2.
+            @if $background-color-basic {
+                --#{tokens.$css-variable-prefix}local-background-color-basic: #{$background-color-basic};
+            }
+
+            // 2.
+            @if $background-color-subtle {
+                --#{tokens.$css-variable-prefix}local-background-color-subtle: #{$background-color-subtle};
             }
 
             @if $background-color-state-hover {


### PR DESCRIPTION
## Description

Every `color-scheme-on-*` class now also sets `--spirit-local-background-color-basic` and
`--spirit-local-background-color-subtle`, regardless of which intensity was picked.

Until now a colour scheme exposed exactly one background: `-subtle` gave `background-subtle`,
`-basic` gave `background-basic`, never both. That makes it impossible to colour a component that
combines the two — a progress bar, for instance, needs the subtle background for its track and the
basic background for its indicator, and no combination of the existing locals bridges the gap
(`border-basic` does happen to equal `background-basic` for every emotion, but the `-basic` scheme
still exposes no subtle background, and `content-basic` is a different, darker colour).

This mirrors the precedent already in the file: `border-color-subtle` is exposed regardless of the
variant, because the dynamic colour helpers always need the subtle border.

For `color-scheme-on-disabled`, which has no background pair of its own, the disabled foreground
stands in for the basic background — it is the colour of a filled element sitting on a disabled
surface. That makes the class able to grey out a component's track, fill and text on its own.

The change is purely additive: two new declarations on the 25 existing utility classes, plus
`background-color-basic()` and `background-color-subtle()` accessor functions. Nothing reads them
yet, so no existing component changes appearance.

### Additional context

Prerequisite for `ProgressBar` (https://github.com/alma-oss/spirit-design-system/pull/2897),
which is stacked on top of this branch. Reviewing this one first keeps the diff honest — the
component PR contains no colour plumbing of its own.

Covered by `packages/web/src/scss/tools/__tests__/_color-scheme.test.scss`: the emotion map
expectations, the `disabled` pairing, the two new accessors, and the emitted custom properties.

### Issue reference

https://jira.almacareer.tech/browse/DS-2402
