### PR TITLE
docs(web-react): add draft CV builder publish screen example page #DS-2765

### DIFF
--- a/packages/web-react/docs/stories/examples/CvBuilderPublish.stories.tsx
+++ b/packages/web-react/docs/stories/examples/CvBuilderPublish.stories.tsx
@@ -1,0 +1,391 @@
+import React, { useMemo, useState } from 'react';
+import {
+  ActionGroup,
+  Box,
+  Breadcrumbs,
+  Button,
+  Checkbox,
+  ControlButton,
+  FieldGroup,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  Icon,
+  InputAddon,
+  Label,
+  Radio,
+  Section,
+  Select,
+  Slider,
+  Stack,
+  StackItem,
+  Text,
+  TextField,
+  Tooltip,
+  TooltipPopover,
+  TooltipTrigger,
+  UNSTABLE_Combobox,
+  UNSTABLE_ComboboxOption,
+  VisuallyHidden,
+} from '../../../src/components';
+import { useToggle } from '../../../src/hooks';
+
+export default {
+  title: 'Examples/Pages',
+  parameters: { layout: 'fullscreen' },
+};
+
+type SalaryType = 'unspecified' | 'specific';
+type StartDateType = 'unspecified' | 'immediately' | 'after-notice' | 'specific';
+
+const SALARY_MIN = 0;
+const SALARY_MAX = 200000;
+const SALARY_STEP = 5000;
+
+const formatSalary = (n: number) => Math.round(n).toString();
+
+const parseSalary = (s: string) => {
+  const digits = s.replace(/\D/g, '');
+
+  return digits === '' ? 0 : Math.min(parseInt(digits, 10), SALARY_MAX);
+};
+
+const JOB_OPTIONS = [
+  { id: 'developer', label: 'Vývojář' },
+  { id: 'designer', label: 'Designer' },
+  { id: 'manager', label: 'Manažer' },
+  { id: 'analyst', label: 'Analytik' },
+  { id: 'tester', label: 'Tester' },
+];
+
+const LOCATION_OPTIONS = [
+  { id: 'prague', label: 'Praha' },
+  { id: 'brno', label: 'Brno' },
+  { id: 'ostrava', label: 'Ostrava' },
+  { id: 'jihlava', label: 'Jihlava' },
+  { id: 'liberec', label: 'Liberec' },
+];
+
+export const CvBuilderPublish = () => {
+  const [salaryType, setSalaryType] = useState<SalaryType>('unspecified');
+  const [startDateType, setStartDateType] = useState<StartDateType>('unspecified');
+  const [salaryValue, setSalaryValue] = useState(50000);
+  const [isHideTooltipOpen, setIsHideTooltipOpen] = useState(false);
+
+  const [isJobOpen, onJobToggle] = useToggle(false);
+  const [jobSelectedKeys, setJobSelectedKeys] = useState<string[]>([]);
+  const [jobInputValue, setJobInputValue] = useState('');
+
+  const [isLocationOpen, onLocationToggle] = useToggle(false);
+  const [locationSelectedKeys, setLocationSelectedKeys] = useState<string[]>([]);
+  const [locationInputValue, setLocationInputValue] = useState('');
+
+  const [isHideCompaniesOpen, onHideCompaniesToggle] = useToggle(false);
+  const [hideCompaniesSelectedKeys, setHideCompaniesSelectedKeys] = useState<string[]>([]);
+  const [hideCompaniesInputValue, setHideCompaniesInputValue] = useState('');
+
+  const filteredJobOptions = useMemo(() => {
+    const query = jobInputValue.trim().toLowerCase();
+
+    return JOB_OPTIONS.filter((option) => option.label.toLowerCase().includes(query));
+  }, [jobInputValue]);
+
+  const filteredLocationOptions = useMemo(() => {
+    const query = locationInputValue.trim().toLowerCase();
+
+    return LOCATION_OPTIONS.filter((option) => option.label.toLowerCase().includes(query));
+  }, [locationInputValue]);
+
+  // @ts-ignore
+  // @ts-ignore
+  return (
+    <>
+      <Section elementType="div" containerProps={{ size: 'large' }} paddingTop="space-1000">
+        <Stack spacing="space-1000">
+          <Breadcrumbs
+            goBackTitle="Zpět"
+            items={[
+              { title: 'Můj Jobs.cz', url: '#' },
+              { title: 'Životopis', url: '#' },
+              { title: 'Vystavit životopis' },
+            ]}
+          />
+          <Heading id="publish-cv-heading" elementType="h1" size="large" fontWeight="semibold" marginBottom="space-0">
+            Jakým firmám se má váš životopis zobrazovat
+          </Heading>
+          <Text marginBottom="space-0">
+            Zadejte obor, ve kterém chcete pracovat, lokalitu, úvazek a mzdu. Můžete si také nastavit, které firmy váš
+            životopis vidět nemají.
+          </Text>
+        </Stack>
+      </Section>
+      <Section elementType="div" size="small" containerProps={{ size: 'large' }}>
+        {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
+                and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
+        <Stack elementType="form" action="#" method="post" aria-labelledby="publish-cv-heading" spacing="space-1000">
+          <Box
+            backgroundColor="primary"
+            borderColor="basic"
+            borderRadius="400"
+            borderWidth="100"
+            paddingX="space-800"
+            paddingY="space-900"
+          >
+            <Stack hasIntermediateDividers spacing="space-900">
+              <StackItem>
+                <Stack spacing="space-700">
+                  {/* TODO: DS-2771 — Combobox popover needs z-index when it's open to be in front of another nodes with higher z-index */}
+                  <UNSTABLE_Combobox
+                    id="publish-job-search"
+                    label="Jakou práci hledáte?"
+                    emptySelectionLabel="Zadejte obor, profesi,…"
+                    isRequired
+                    isOpen={isJobOpen}
+                    onToggle={onJobToggle}
+                    selectedKeys={jobSelectedKeys}
+                    onSelectionChange={setJobSelectedKeys}
+                    inputValue={jobInputValue}
+                    onInputChange={setJobInputValue}
+                    optionKeys={JOB_OPTIONS.map((o) => o.id)}
+                    hasEmptyState={filteredJobOptions.length === 0}
+                  >
+                    {filteredJobOptions.map((option) => (
+                      <UNSTABLE_ComboboxOption key={option.id} value={option.id}>
+                        <Label>{option.label}</Label>
+                      </UNSTABLE_ComboboxOption>
+                    ))}
+                  </UNSTABLE_Combobox>
+                  <UNSTABLE_Combobox
+                    id="publish-location-search"
+                    label="Ve kterém městě nebo kraji chcete pracovat?"
+                    emptySelectionLabel="Jihlava"
+                    isRequired
+                    isOpen={isLocationOpen}
+                    onToggle={onLocationToggle}
+                    selectedKeys={locationSelectedKeys}
+                    onSelectionChange={setLocationSelectedKeys}
+                    inputValue={locationInputValue}
+                    onInputChange={setLocationInputValue}
+                    optionKeys={LOCATION_OPTIONS.map((o) => o.id)}
+                    hasEmptyState={filteredLocationOptions.length === 0}
+                  >
+                    {filteredLocationOptions.map((option) => (
+                      <UNSTABLE_ComboboxOption key={option.id} value={option.id}>
+                        <Label>{option.label}</Label>
+                      </UNSTABLE_ComboboxOption>
+                    ))}
+                  </UNSTABLE_Combobox>
+                  <Checkbox id="publish-remote" name="remote" label="Chci pracovat z domova (remote)" />
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <FieldGroup id="publish-job-type" label="Jaký typ úvazku preferujete?" isRequired>
+                  <Checkbox id="publish-job-type-full" name="jobType" label="Plný" />
+                  <Checkbox id="publish-job-type-part" name="jobType" label="Zkrácený" />
+                </FieldGroup>
+              </StackItem>
+
+              <StackItem>
+                <Stack spacing="space-800">
+                  <FieldGroup id="publish-salary" label="Očekávaná hrubá mzda">
+                    <Radio
+                      id="publish-salary-unspecified"
+                      name="salary"
+                      label="Neurčeno"
+                      isChecked={salaryType === 'unspecified'}
+                      onChange={() => setSalaryType('unspecified')}
+                    />
+                    <Radio
+                      id="publish-salary-gross"
+                      name="salary"
+                      label="Zadám hrubou mzdu"
+                      isChecked={salaryType === 'specific'}
+                      {...(salaryType === 'specific' && {
+                        'aria-controls': 'publish-salary-amount',
+                      })}
+                      onChange={() => setSalaryType('specific')}
+                    />
+                  </FieldGroup>
+                  {salaryType === 'specific' && (
+                    <Grid cols={{ mobile: 1, tablet: 2, desktop: 4 }}>
+                      <GridItem>
+                        <Stack spacing="space-800">
+                          <TextField
+                            id="publish-salary-amount"
+                            label="Hrubá mzda od"
+                            value={formatSalary(salaryValue)}
+                            onChange={(e) => setSalaryValue(parseSalary(e.target.value))}
+                            endAddon={<InputAddon>Kč</InputAddon>}
+                            min={SALARY_MIN}
+                            max={SALARY_MAX}
+                            type="number"
+                            aria-labelledby="publish-salary-gross"
+                          />
+                          <Slider
+                            id="publish-salary-slider"
+                            label="Hrubá mzda"
+                            isLabelHidden
+                            min={SALARY_MIN}
+                            max={SALARY_MAX}
+                            step={SALARY_STEP}
+                            value={salaryValue}
+                            onChange={(e) => setSalaryValue(Number(e.target.value))}
+                            // We are hiding `Slider` for assistive technologies because
+                            // it shared the same value as `TextField`. Moreover the `TextField`
+                            // should be much easier for users to control than `Slider`.
+                            aria-hidden="true"
+                          />
+                        </Stack>
+                      </GridItem>
+                    </Grid>
+                  )}
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <Stack spacing="space-700">
+                  <FieldGroup id="publish-start-date" label="Kdy můžete nastoupit?">
+                    <Radio
+                      id="publish-start-unspecified"
+                      name="startDate"
+                      label="Neurčeno"
+                      isChecked={startDateType === 'unspecified'}
+                      onChange={() => setStartDateType('unspecified')}
+                    />
+                    <Radio
+                      id="publish-start-immediately"
+                      name="startDate"
+                      label="Okamžitě"
+                      isChecked={startDateType === 'immediately'}
+                      onChange={() => setStartDateType('immediately')}
+                    />
+                    <Radio
+                      id="publish-start-notice"
+                      name="startDate"
+                      label="Po uplynutí výpovědní doby"
+                      isChecked={startDateType === 'after-notice'}
+                      onChange={() => setStartDateType('after-notice')}
+                    />
+                    <Radio
+                      id="publish-start-date-specific"
+                      name="startDate"
+                      label="Zadám přesné datum"
+                      isChecked={startDateType === 'specific'}
+                      {...(startDateType === 'specific' && {
+                        'aria-controls': 'publish-start-month publish-start-year',
+                      })}
+                      onChange={() => setStartDateType('specific')}
+                    />
+                  </FieldGroup>
+                  {startDateType === 'specific' && (
+                    <Flex spacing="space-700" alignmentY="bottom">
+                      <Select
+                        id="publish-start-month"
+                        label="Datum nástupu"
+                        aria-labelledby="publish-start-date-specific"
+                      >
+                        <option value="1">Leden</option>
+                        <option value="2">Únor</option>
+                        <option value="3">Březen</option>
+                        <option value="4">Duben</option>
+                        <option value="5">Květen</option>
+                        <option value="6">Červen</option>
+                        <option value="7">Červenec</option>
+                        <option value="8">Srpen</option>
+                        <option value="9">Září</option>
+                        <option value="10">Říjen</option>
+                        <option value="11">Listopad</option>
+                        <option value="12">Prosinec</option>
+                      </Select>
+                      <Select id="publish-start-year" label="Rok" isLabelHidden>
+                        <option value="2025">2025</option>
+                        <option value="2026">2026</option>
+                        <option value="2027">2027</option>
+                      </Select>
+                    </Flex>
+                  )}
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <FieldGroup id="publish-additional" label="Doplňující údaje">
+                  <Checkbox id="publish-ico" name="additional" label="Mohu pracovat na IČ" />
+                  <Checkbox id="publish-disability" name="additional" label="Jsem osoba se zdravotním postižením" />
+                </FieldGroup>
+              </StackItem>
+
+              <StackItem>
+                {/* TODO: DS-2771 — Combobox popover needs z-index when it's open to be in front of another nodes with higher z-index */}
+                {/* TODO: DS-2790 — label prop type is `string`; passing ReactNode causes
+                    TS2322: Type 'Element' is not assignable to type 'string'. Suppressed until fixed. */}
+                <UNSTABLE_Combobox
+                  id="publish-hide-companies"
+                  emptySelectionLabel="Uveďte název firmy"
+                  /* @ts-ignore – ReactNode isn't supported by the `label` -- @see https://jira.almacareer.tech/browse/DS-2790 */
+                  label={
+                    <>
+                      Chcete životopis skrýt před některými firmami?{' '}
+                      {/* TODO: DS-2773 — Vertical alignment should be handled by the component or label styles rather than UNSAFE_ overrides. */}
+                      <Tooltip
+                        elementType="span"
+                        id="publish-hide-tooltip"
+                        isOpen={isHideTooltipOpen}
+                        onToggle={setIsHideTooltipOpen}
+                        placement="top-start"
+                        aria-hidden="true"
+                        UNSAFE_style={{ verticalAlign: 'middle' }}
+                      >
+                        {/* TODO: DS-2772 — TooltipTrigger should set type="button" when elementType is a button to prevent accidental form submission. */}
+                        <ControlButton elementType={TooltipTrigger} type="button" isSymmetrical isSubtle size="small">
+                          <Icon name="info" />
+                          <VisuallyHidden>Více informací</VisuallyHidden>
+                        </ControlButton>
+                        <TooltipPopover id="publish-tooltip-popover">
+                          Když nechcete, aby některé firmy nebo organizace váš životopis viděly, zadejte jejich názvy.
+                          Hodí se to u firem, se kterými nemáte dobré zkušenosti, nebo třeba u současného
+                          zaměstnavatele.
+                        </TooltipPopover>
+                      </Tooltip>
+                    </>
+                  }
+                  isOpen={isHideCompaniesOpen}
+                  onToggle={onHideCompaniesToggle}
+                  selectedKeys={hideCompaniesSelectedKeys}
+                  onSelectionChange={setHideCompaniesSelectedKeys}
+                  inputValue={hideCompaniesInputValue}
+                  onInputChange={setHideCompaniesInputValue}
+                  optionKeys={[]}
+                  hasEmptyState={false}
+                  aria-describedby="publish-hide-companies-additional-info"
+                />
+                <VisuallyHidden id="publish-hide-companies-additional-info">
+                  Když nechcete, aby některé firmy nebo organizace váš životopis viděly, zadejte jejich názvy. Hodí se
+                  to u firem, se kterými nemáte dobré zkušenosti, nebo třeba u současného zaměstnavatele.
+                </VisuallyHidden>
+              </StackItem>
+              <StackItem>
+                <Stack spacing="space-900">
+                  <ActionGroup
+                    direction={{ mobile: 'vertical', tablet: 'horizontal' }}
+                    alignmentX={{ mobile: 'stretch', tablet: 'left' }}
+                    spacing="space-600"
+                  >
+                    <Button type="submit">Vystavit životopis</Button>
+                    <Button color="secondary">Zrušit</Button>
+                  </ActionGroup>
+                  <Text textColor="secondary">
+                    Vystavením životopisu zpřístupníte údaje personalistům, tj. našim klientům/zaměstnavatelům, kteří
+                    mají přístup do databáze životopisů. Personalisté z celé Evropy Vás budou moci najít v databázi
+                    podle Vámi zadaných informací/kritérií a budou Vás moci oslovit s pracovní nabídkou
+                  </Text>
+                </Stack>
+              </StackItem>
+            </Stack>
+          </Box>
+        </Stack>
+      </Section>
+    </>
+  );
+};


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The publish-CV screen from the [New Jobs.cz Handoff Figma file][figma-desktop] needed a real render before hand-off, to see how much of it Spirit's components already cover. This adds it as a throwaway `Examples/Pages` Storybook story composed only of Spirit components — nothing in `src/`, so it is a deletable file rather than shipped code. Opening as a draft: the point is to review the composition and the DS gaps it surfaced, not to merge it. Follows the same approach as #2879 and #2893.

### Page structure

```
CvBuilderPublish
├─ Section₁ (elementType: div, paddingTop: 1000, container: large)   — page intro
│  └─ Stack (spacing: 1000)
│     ├─ Breadcrumbs (goBackTitle: "Zpět")
│     ├─ Heading (h1, id: publish-cv-heading, size: large, fontWeight: semibold)
│     │  "Jakým firmám se má váš životopis zobrazovat"
│     └─ Text "Zadejte obor..."
│
└─ Section₂ (elementType: div, size: small, container: large)        — form
   └─ Stack (elementType: form, aria-labelledby → h1, spacing: 1000)
      └─ Box (bg: primary, border: basic, borderWidth: 100, radius: 400,
              paddingX: 800, paddingY: 900)
         └─ Stack (hasIntermediateDividers, spacing: 900)
            │
            ├─ StackItem — job + location + remote
            │  └─ Stack (spacing: 700)
            │     ├─ UNSTABLE_Combobox "Jakou práci hledáte?" (required)
            │     ├─ UNSTABLE_Combobox "Ve kterém městě nebo kraji…" (required)
            │     └─ Checkbox "Chci pracovat z domova (remote)"
            │
            ├─ StackItem — job type
            │  └─ FieldGroup "Jaký typ úvazku preferujete?" (required)
            │     ├─ Checkbox "Plný"
            │     └─ Checkbox "Zkrácený"
            │
            ├─ StackItem — salary (partly conditional)
            │  └─ Stack (spacing: 800)
            │     ├─ FieldGroup "Očekávaná hrubá mzda"
            │     │  ├─ Radio "Neurčeno"
            │     │  └─ Radio "Zadám hrubou mzdu"
            │     │           aria-expanded, aria-controls → conditional fields
            │     └─ [when "Zadám hrubou mzdu" selected]
            │        └─ Grid (cols: { mobile: 1, tablet: 2, desktop: 4 })
            │           └─ GridItem (elementType: Stack, spacing: 800)
            │              ├─ TextField "Hrubá mzda od" (endAddon: "Kč",
            │              │            controlled ↔ salaryValue)
            │              └─ Slider (isLabelHidden, min: 0, max: 200 000,
            │                         controlled ↔ salaryValue)
            │
            ├─ StackItem — start date (partly conditional)
            │  └─ Stack (spacing: 700)
            │     ├─ FieldGroup "Kdy můžete nastoupit?"
            │     │  ├─ Radio "Neurčeno"
            │     │  ├─ Radio "Okamžitě"
            │     │  ├─ Radio "Po uplynutí výpovědní doby"
            │     │  └─ Radio "Zadám přesné datum"
            │     │           aria-expanded, aria-controls → id: publish-start-date-inputs
            │     └─ [when "Zadám přesné datum" selected]
            │        └─ Flex (id: publish-start-date-inputs, spacing: 700, alignmentY: bottom)
            │           ├─ Select "Datum nástupu"
            │           └─ Select (isLabelHidden, label: "Rok")
            │
            ├─ StackItem — additional info
            │  └─ FieldGroup "Doplňující údaje"
            │     ├─ Checkbox "Mohu pracovat na IČ"
            │     └─ Checkbox "Jsem osoba se zdravotním postižením"
            │
            ├─ StackItem — hide CV from companies
            │  └─ TextField (size: large)
            │     label: text + Tooltip (elementType: span, placement: top-start)
            │                      └─ TooltipTrigger (type: button)
            │                            → Icon "info" (aria-hidden) + VisuallyHidden "Více informací"
            │
            └─ StackItem — actions + legal
               └─ Stack (spacing: 900)
                  ├─ ActionGroup (direction: { mobile: vertical, tablet: horizontal },
                  │               alignmentX: { mobile: stretch, tablet: left }, spacing: 600)
                  │  ├─ Button type="submit" "Vystavit životopis"
                  │  └─ Button color="secondary" "Zrušit"
                  └─ Text (textColor: secondary) — legal disclaimer
```

Section₁ uses only `paddingTop` (no bottom padding) so that the gap between the intro band and the form band equals a single Section's top padding — no doubling. Section₂ carries the full `size="small"` symmetric padding. Both are `elementType="div"` for the same reason as #2879: they're full-bleed background bands, not genuine outline subsections.

### Accessibility tree

```
<body>
├─ div                                    — role: generic (Section₁ intro band)
│  ├─ nav "Breadcrumb"                    — landmark: navigation
│  │  └─ list
│  │     └─ listitem → link "Životopis"
│  ├─ h1 "Jakým firmám se má váš životopis zobrazovat"
│  │           id: publish-cv-heading
│  └─ p "Zadejte obor…"
│
└─ form "Jakým firmám se má váš životopis zobrazovat"
         — landmark: form (named via aria-labelledby → h1 in Section₁)
   ├─ combobox "Jakou práci hledáte? *"        — required
   ├─ combobox "Ve kterém městě nebo kraji… *"  — required
   ├─ label + checkbox "Chci pracovat z domova (remote)"
   ├─ fieldset                                  — FieldGroup
   │  ├─ legend "Jaký typ úvazku preferujete? *" (VisuallyHidden) + visible div label
   │  ├─ label + checkbox "Plný"
   │  └─ label + checkbox "Zkrácený"
   ├─ fieldset                                  — FieldGroup
   │  ├─ legend "Očekávaná hrubá mzda" (VisuallyHidden) + visible div label
   │  ├─ label + radio "Neurčeno"
   │  └─ label + radio "Zadám hrubou mzdu"
   │           aria-expanded: false → true on select
   │           aria-controls (conditional — absent when fields are not in DOM)
   ├─ [conditional] label + input "Hrubá mzda od" — controlled, endAddon "Kč"
   ├─ [conditional] label (hidden) + input type="range"  — controlled, same value
   ├─ fieldset                                  — FieldGroup
   │  ├─ legend "Kdy můžete nastoupit?" (VisuallyHidden) + visible div label
   │  ├─ label + radio "Neurčeno"
   │  ├─ label + radio "Okamžitě"
   │  ├─ label + radio "Po uplynutí výpovědní doby"
   │  └─ label + radio "Zadám přesné datum"
   │           aria-expanded: false → true on select
   │           aria-controls (conditional — absent when selects are not in DOM)
   ├─ [conditional] label + select "Datum nástupu"
   ├─ [conditional] select (hidden label "Rok")
   ├─ fieldset                                  — FieldGroup
   │  ├─ legend "Doplňující údaje" (VisuallyHidden) + visible div label
   │  ├─ label + checkbox "Mohu pracovat na IČ"
   │  └─ label + checkbox "Jsem osoba se zdravotním postižením"
   ├─ label "Chcete životopis skrýt před některými firmami?"
   │  + button "Více informací" (type: button)  — Tooltip trigger, Icon aria-hidden
   ├─ input (size: large)                       — hide-companies text field
   ├─ div                                       — role: generic (ActionGroup)
   │  ├─ button "Vystavit životopis" (type: submit)
   │  └─ button "Zrušit"
   └─ p — legal disclaimer
```

- **`<form>` is a landmark** because it carries `aria-labelledby` pointing to the page `h1` — a named `<form>` exposes the `form` role to the accessibility tree, making it reachable by landmark navigation. An unnamed `<form>` does not.
- **`Breadcrumbs` uses `aria-label="Breadcrumb"`** — hardcoded English regardless of locale, the same known issue noted in [DS-2747](https://jira.almacareer.tech/browse/DS-2747) from #2879.
- **`aria-controls` is conditional**: the attribute is only present on a Radio when its controlled fields are in the DOM. When the radio is unselected the fields are removed from the DOM, so omitting `aria-controls` avoids an invalid ARIA reference; `aria-expanded` alone signals the collapsed state. Follows the same pattern as DS-2746 / #2893.
- **`TooltipTrigger type="button"`** — explicit workaround for DS-2772: without it, the trigger would submit the form.

### Additional context

Figma nodes: [desktop (6976-69588)][figma-desktop] · [mobile (4042-30995)][figma-mobile]

Storybook: `Examples/Pages` → `Cv Builder Publish`

The Figma library belongs to a different product built on the same Spirit token system, so pixel-for-pixel parity is not expected — everything renders with this repo's own Spirit token values.

### Design considerations

ℹ️ For the Spirit Design System team.

Genuine gaps the design ran into, worth a look:

- The Figma "Search Field" component is an autocomplete with tag-chip selection — no Spirit equivalent. Approximated with `UNSTABLE_Combobox` (closest available primitive, static options in the story).
- The card carries a static `shadow-100`, which has no Spirit `Box` prop (`Card` applies it on hover only), so it is left out.
- The ⓘ icon next to the "hide companies" label is a Figma SVG asset, not a Spirit icon name. Mapped to `Icon name="info"` as the closest approximation.

### Developer considerations

ℹ️ For the Spirit Design System team.

TODOs left in the story, filed under the [DS-2758](https://jira.almacareer.tech/browse/DS-2758) "CV editor follow-up" epic — 🚨 bug, ✨ feature:

- 🚨 [DS-2771](https://jira.almacareer.tech/browse/DS-2771) — `UNSTABLE_Combobox` popover overlapped by subsequent DOM elements due to z-index stacking
- 🚨 [DS-2772](https://jira.almacareer.tech/browse/DS-2772) — `TooltipTrigger` missing default `type="button"` causes form submission when clicked inside a form
- ✨ [DS-2773](https://jira.almacareer.tech/browse/DS-2773) — `TooltipTrigger` inline icon in form field labels requires `UNSAFE_` overrides
- 🚨 [DS-2790](https://jira.almacareer.tech/browse/DS-2790) – UNSTABLE_Combobox: label prop type too narrow — does not accept ReactNode

### Issue reference

https://jira.almacareer.tech/browse/DS-2765

Follow-up epic: https://jira.almacareer.tech/browse/DS-2758

[figma-desktop]: https://www.figma.com/design/8ufvVYLhsORI03CFpweNHk/New-Jobs.cz-Handoff?node-id=6976-69588
[figma-mobile]: https://www.figma.com/design/8ufvVYLhsORI03CFpweNHk/New-Jobs.cz-Handoff?node-id=4042-30995