### PR TITLE
fix(ci): key yarn cache by lockfile hash only, not branch name

### DIFF
--- a/.github/actions/setup-install/action.yaml
+++ b/.github/actions/setup-install/action.yaml
@@ -16,9 +16,9 @@ runs:
       uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ./.yarn/cache
-        key: ${{ runner.os }}-Yarn-main
+        key: ${{ runner.os }}-Yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
-          ${{ runner.os }}-Yarn-main-
+          ${{ runner.os }}-Yarn-
 
     - name: Install dependencies
       uses: ./.github/actions/deps-install

--- a/.github/workflows/cache-dependencies.yaml
+++ b/.github/workflows/cache-dependencies.yaml
@@ -6,7 +6,8 @@
 #
 # @see: https://classic.yarnpkg.com/blog/2016/11/24/offline-mirror/
 #
-# The cache is created once per day, or can be manually triggered.
+# The cache is keyed by OS + yarn.lock hash only (no branch name), so it is
+# created once per day (always against main), or can be manually triggered.
 # Every install on every branch will use the same cache if available.
 # Or install all the dependencies from scratch if not.
 # The thing is, even if same dependencies changed or are missing, only those
@@ -44,6 +45,7 @@ jobs:
     name: 🔄 Update Dependencies Cache
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    if: ${{ github.ref_name == 'main' }}
     permissions:
       actions: write
       contents: read
@@ -70,7 +72,7 @@ jobs:
         id: cache-key
         run: |
           HASH="${{ hashFiles('**/yarn.lock') }}"
-          echo "key=${{ runner.os }}-Yarn-${{ github.ref_name }}-${HASH}" >> $GITHUB_OUTPUT
+          echo "key=${{ runner.os }}-Yarn-${HASH}" >> $GITHUB_OUTPUT
           echo "hash=${HASH}" >> $GITHUB_OUTPUT
 
       - name: Check Cache


### PR DESCRIPTION
## Description

The daily yarn dependency cache workflow keyed its cache by `${{ runner.os }}-Yarn-${{ github.ref_name }}-<yarn.lock hash>`, while every consuming workflow (`setup-install`) restored a hardcoded `${{ runner.os }}-Yarn-main` key. This only worked by accident because the scheduled trigger always runs against the default branch. A manual `workflow_dispatch` on a non-`main` branch would create a branch-scoped cache, and the subsequent purge step would then delete the shared `main` cache (it only excludes the just-created key), leaving every other workflow with a permanent cache miss until the next scheduled run.

Dropped the branch name from the cache key entirely (branches sharing a `yarn.lock` don't need separate caches) and updated `setup-install` to restore using the same hash-based key, with a shared `-Yarn-` prefix as a fallback. Also added a guard so the cache-management job can only run when triggered on `main`, so it can no longer be dispatched against another branch by mistake.

### Additional context

Currently there's only one cache entry (`Linux-Yarn-main-<hash>`) in the repo's Actions cache, so this bug hasn't caused visible breakage yet — it's a latent issue that would only surface on an off-schedule manual run against a non-main branch.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->