### PR TITLE
fix(docsite): load missing typefaces and italics

### DIFF
--- a/apps/docsite/src/app/global-not-found.tsx
+++ b/apps/docsite/src/app/global-not-found.tsx
@@ -2,7 +2,7 @@ import { ButtonLink, EmptyState, EmptyStateSection, Flex, Heading, Section, Text
 import { routes } from '@local/domains/routing/routes';
 import { Header, Footer } from '@local/ui';
 import { AppProvider } from '@local/ui/AppProvider';
-import { inter } from '@local/ui/fonts';
+import { fontshareApiUrl, generalSansStylesheet } from '@local/ui/fonts';
 import { Metadata } from 'next';
 import '../ui/globals.scss';
 
@@ -14,7 +14,11 @@ export const metadata: Metadata = {
 
 const GlobalNotFound = () => (
   <html lang="en">
-    <body className={`${inter.className} antialiased`}>
+    <head>
+      <link rel="preconnect" href={fontshareApiUrl} />
+      <link rel="stylesheet" href={generalSansStylesheet} />
+    </head>
+    <body>
       <AppProvider>
         <Header disableClientRouting />
         <Flex elementType="main" alignmentX="center" alignmentY="center">

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from '@alma-oss/spirit-web-react';
 import { type ChildrenProps } from '@local/types';
 import { Footer } from '@local/ui';
 import { AppProvider } from '@local/ui/AppProvider';
-import { inter } from '@local/ui/fonts';
+import { fontshareApiUrl, generalSansStylesheet } from '@local/ui/fonts';
 import '@local/ui/globals.scss';
 import { Header } from '@local/ui/Header';
 import { Metadata } from 'next';
@@ -21,7 +21,11 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: RootLayoutProps) => (
   <html lang="en">
-    <body className={`${inter.className} antialiased`}>
+    <head>
+      <link rel="preconnect" href={fontshareApiUrl} />
+      <link rel="stylesheet" href={generalSansStylesheet} />
+    </head>
+    <body>
       <AppProvider>
         <Header />
         <main>

--- a/apps/docsite/src/ui/fonts.ts
+++ b/apps/docsite/src/ui/fonts.ts
@@ -1,3 +1,18 @@
-import { Inter } from 'next/font/google';
+import { Inter, Roboto_Mono as RobotoMono } from 'next/font/google';
 
-export const inter = Inter({ subsets: ['latin'] });
+// Bindings are required by next/font. Importing this module emits @font-face
+// for Spirit's `'Inter'` and `'Roboto Mono'` families; the class names are unused.
+export const inter = Inter({
+  subsets: ['latin', 'latin-ext'],
+  style: ['normal', 'italic'],
+  display: 'swap',
+});
+
+export const robotoMono = RobotoMono({
+  subsets: ['latin', 'latin-ext'],
+  style: ['normal', 'italic'],
+  display: 'swap',
+});
+
+export const fontshareApiUrl = 'https://api.fontshare.com';
+export const generalSansStylesheet = `${fontshareApiUrl}/v2/css?f%5B%5D=general-sans@700&display=swap`;

--- a/apps/docsite/src/ui/globals.scss
+++ b/apps/docsite/src/ui/globals.scss
@@ -1,6 +1,7 @@
 @forward '@alma-oss/spirit-web/src/scss';
 @use '@alma-oss/spirit-web/src/scss/tools/breakpoint';
-@use 'devices/devices' as tokens;
+@use '@alma-oss/spirit-web/src/scss/tools/typography';
+@use '@tokens' as tokens;
 
 // 1. Expand the page to fill the viewport height to be ready for various themes.
 // 2. Make the footer sticky.
@@ -147,12 +148,11 @@ body {
 }
 
 .docs-Markdown code:not(pre code) {
+    @include typography.generate(tokens.$code-small-regular);
+
     background: var(--spirit-color-background-secondary);
-    color: var(--spirit-color-neutral-content-strong);
     padding: 0.1em 0.4em;
     border-radius: var(--spirit-radius-200);
-    font-size: 0.95em;
-    font-family: var(--spirit-font-mono, 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', monospace);
     word-break: break-word;
     white-space: pre-wrap;
     vertical-align: baseline;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The docsite only loaded Inter (normal) through `next/font`, so italic text was synthesized, code samples fell back to system mono, and display styles never resolved General Sans. Inter and Roboto Mono now load through `next/font` with italics so `@font-face` matches Spirit family names; General Sans uses the Fontshare CSS API like demo and Storybook, because committing the files would redistribute a Closed Source font in a public repo.

`next/font` class names are not applied on `<html>`/`<body>` — Spirit already sets `font-family` on `:where(body)` and the typography tokens.

### Additional context

Fontshare's ITF Free Font License allows self-hosting on our own site, but not putting the font files in a public repository. Reviewers can check italics on `Text`/`Heading` and display styles that use General Sans.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->