### PR TITLE
docs(repo): add 2026-09-02 release notes

### DIFF
--- a/docs/release-notes/2026-09-02.md
+++ b/docs/release-notes/2026-09-02.md
@@ -1,0 +1,103 @@
+# 2026-09-02 Spirit Design System Release Notes
+
+📢 🚀 🎉 Ahoy, we have a new release with features and improvements. Here we go.
+
+## General Changes
+
+This release delivers the multi-select search experience we've been building toward: `UNSTABLE_Combobox` is here, paired with `UNSTABLE_SplitTag` and `UNSTABLE_ComboboxSplitTag` for hosting a nested select directly inside a tag (think distance/radius pickers), plus shared selection and Collection patterns that now power both `Picker` and `Combobox`. Give them a spin and send us feedback — they're unstable for a reason.
+
+You can also reach for `UNSTABLE_DisplayHeading` for large marketing headings, and the new `fontWeight`/`isItalic` props (replacing the deprecated `emphasis`) for finer text emphasis. Under the hood, `PropsContext` now supports namespaced context groups for cleaner prop cascading.
+
+## News in Packages
+
+&nbsp;
+
+📦 **Web React _5.3.0_** `@alma-oss/spirit-web-react`
+
+### Features
+
+- Add **isStretched** prop to `ControlButton` ([2231ff8](https://github.com/alma-oss/spirit-design-system/commit/2231ff8f05ffc0d0d566fddc3755c8b957838fa8))
+- Add context support for split tag composition ([a91984a](https://github.com/alma-oss/spirit-design-system/commit/a91984acf81ff456f29ee9b56d21936c64886067))
+- Add namespace groups to `PropsContext` #DS-2447 ([5fbe9bc](https://github.com/alma-oss/spirit-design-system/commit/5fbe9bc8fe8bd066445e5d77bce2ccd126d08331))
+- Introduce namespaced context props and extensible group contexts in `PropsContext` #DS-2447 ([d0e4449](https://github.com/alma-oss/spirit-design-system/commit/d0e44490a694326d037e177f3e1d65e6be2969fc), [a0d02dd](https://github.com/alma-oss/spirit-design-system/commit/a0d02dd367add2ef507f24026b612e003bba13ed))
+- Introduce `UNSTABLE_SplitTag` component ([26fd3a0](https://github.com/alma-oss/spirit-design-system/commit/26fd3a005790519a0342bcfbbd49717b9bc5ccf9))
+- Adopt selection pattern for `Picker` and `Combobox` #DS-2698 ([915be05](https://github.com/alma-oss/spirit-design-system/commit/915be05199070615f48226d6958f2024d3fae5b9))
+- Enable `NavigationAvatar` as dropdown trigger via context ([6a7b6ef](https://github.com/alma-oss/spirit-design-system/commit/6a7b6efe828e2aac41402399482aad7a9840e9a3))
+- Introduce **fontWeight** and **isItalic**, deprecate **emphasis** #DS-2725 ([3e5e3b6](https://github.com/alma-oss/spirit-design-system/commit/3e5e3b69201d4cabd72eaa797e16a6ad6de55f08))
+- Introduce `UNSTABLE_Combobox` component #DS-2304 ([d10670e](https://github.com/alma-oss/spirit-design-system/commit/d10670e9c01438e658fc4ceea3d1b5ead3c07a96))
+- Introduce `UNSTABLE_ComboboxSplitTag` for select segments #DS-2708 ([044bdb2](https://github.com/alma-oss/spirit-design-system/commit/044bdb2c56e316cd89d787eedca02ded8770faa1))
+- Introduce `UNSTABLE_DisplayHeading` #DS-2779 ([bc5e2de](https://github.com/alma-oss/spirit-design-system/commit/bc5e2de72c7e1f6dc1c71c134d60f9c2fa2c2469))
+- Introduce Collection pattern for `Picker` and `Combobox` #DS-2699 ([5bb0668](https://github.com/alma-oss/spirit-design-system/commit/5bb066847b04f6347ae21d7b32e0a6ebbe291284))
+- Introduce accessible disclosure hooks (`useDisclosureState`, `useDisclosureAria`) for building collapsible trigger/panel patterns #DS-2519 ([0bbb23b](https://github.com/alma-oss/spirit-design-system/commit/0bbb23bebcb5cc0c63b5b183db8bdf58f3940dac))
+- Make `PaginationLink` generic and deprecate `PaginationButtonLink` #DS-2684 ([ff9a041](https://github.com/alma-oss/spirit-design-system/commit/ff9a041ad10b51e36f8f42f209b74e86fba0bd17))
+- Support `SplitTag` selection in `UNSTABLE_Combobox` #DS-2708 ([92304cd](https://github.com/alma-oss/spirit-design-system/commit/92304cdb822dda450e8056be080717babb6afca1))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-web-react@5.2.1...@alma-oss/spirit-web-react@5.3.0)
+
+&nbsp;
+
+📦 **Web _5.1.0_** `@alma-oss/spirit-web`
+
+### Features
+
+- Introduce `UNSTABLE_Combobox` component #DS-2304 ([d10670e](https://github.com/alma-oss/spirit-design-system/commit/d10670e9c01438e658fc4ceea3d1b5ead3c07a96))
+- Introduce `UNSTABLE_DisplayHeading` #DS-2779 ([bc5e2de](https://github.com/alma-oss/spirit-design-system/commit/bc5e2de72c7e1f6dc1c71c134d60f9c2fa2c2469))
+- Introduce `UNSTABLE_SplitTag` styles and demo ([118a112](https://github.com/alma-oss/spirit-design-system/commit/118a112706469065b59d313e322a093b25c9bb53))
+- Add `Combobox` locations `SplitTag` demo and nested stacking #DS-2708 ([566e8ef](https://github.com/alma-oss/spirit-design-system/commit/566e8ef69332a7725aa079cff00b73c14330c099))
+- Add keyboard navigation to `Dropdown` #DS-1609 ([9089d81](https://github.com/alma-oss/spirit-design-system/commit/9089d81d9e617d2d2767ec23f7d66ad01b0e986b))
+- Delegate `Combobox` Escape handling to `Dropdown` #DS-1609 ([c6db4a6](https://github.com/alma-oss/spirit-design-system/commit/c6db4a6cefe06b45c134296105a0cc083422b9a4))
+- Introduce `.text-italic` helper #DS-2725 ([fef3712](https://github.com/alma-oss/spirit-design-system/commit/fef3712783054721a36f3f970e72d22f93e9f2b9))
+- Style `Pagination` links with radius tokens and disabled state #DS-2684 ([327841b](https://github.com/alma-oss/spirit-design-system/commit/327841b9bbb0739a3c8728bb97468da24bb5a24c))
+
+### Bug Fixes
+
+- Inherit nested `Tag` radius from `InputContainer` #DS-2710 ([62f6f8f](https://github.com/alma-oss/spirit-design-system/commit/62f6f8fdd7ee941966f0bf48574cbc0782a2484e))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-web@5.0.3...@alma-oss/spirit-web@5.1.0)
+
+&nbsp;
+
+📦 **Design Tokens _5.1.0_** `@alma-oss/spirit-design-tokens`
+
+### Features
+
+- Add pagination radius tokens #DS-2684 ([4e70b61](https://github.com/alma-oss/spirit-design-system/commit/4e70b612d1b131e69f6d6aa09e649991e7037a8b))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-design-tokens@5.0.1...@alma-oss/spirit-design-tokens@5.1.0)
+
+&nbsp;
+
+📦 **Codemods _3.1.0_** `@alma-oss/spirit-codemods`
+
+### Features
+
+- Migrate `PaginationButtonLink` to previous/next links #DS-2684 ([1558dca](https://github.com/alma-oss/spirit-design-system/commit/1558dcaec0c30ecfd094ea9ab99b85bf465fb520))
+- Add namespaced context props to `PropsContext` #DS-2447 ([d0e4449](https://github.com/alma-oss/spirit-design-system/commit/d0e44490a694326d037e177f3e1d65e6be2969fc))
+- Introduce **fontWeight** and **isItalic**, deprecate **emphasis** #DS-2725 ([3e5e3b6](https://github.com/alma-oss/spirit-design-system/commit/3e5e3b69201d4cabd72eaa797e16a6ad6de55f08))
+
+[Full changelog](https://github.com/alma-oss/spirit-design-system/compare/@alma-oss/spirit-codemods@3.0.1...@alma-oss/spirit-codemods@3.1.0)
+
+## What's Next 🔮
+
+- **Progress Bar**
+  A new progress indicator for standalone use and inside file upload flows, landing for both `web` and `web-react` — this is the current sprint's focus.
+
+- **Tile**
+  A new component rounding out the `Box` / `Tile` / `Card` family, giving you a lighter-weight surface between a plain `Box` and a full `Card`.
+
+- **Non-modal Dialog**
+  React `Dialog` will support a non-modal mode, opening the door to lighter-weight overlay patterns that don't block the rest of the page.
+
+🎯 You can see more of our [quarterly targets outlook in Notion](https://www.notion.so/almacareer/Spirit-DS-team-Quarterly-Goals-878e92d5b74543039e513c0160fb9117).
+
+## We'd Love to Hear Your Feedback
+
+💬 If you have any ideas, suggestions, or requests regarding the newly introduced unstable components, or if you just need help or want to report a bug or wrong behavior, please get in touch with us on our Slack channel: [#spirit-design-system-support_cs_en](https://slack.com/archives/C068XPSDWQN).
+
+&nbsp;
+
+🐙 Everything is available in our [repository on GitHub](https://github.com/alma-oss/spirit-design-system/).
+
+&nbsp;
+
+Thank you for staying with us!


### PR DESCRIPTION
## Summary
- Adds the Slack-ready release notes for the 2026-09-02 publish (Web React 5.3.0, Web 5.1.0, Design Tokens 5.1.0, Codemods 3.1.0).
- Highlights `UNSTABLE_Combobox`/`UNSTABLE_SplitTag`, `UNSTABLE_DisplayHeading`, `fontWeight`/`isItalic`, and the `PaginationLink` deprecation + codemod.
- "What's Next" pulled from the active/upcoming Jira sprints (Progress Bar, Tile, non-modal Dialog).

⚠️ Note: a Code Refactoring entry (`[web-react] replace ControlButton dismiss with CloseButton in File, Item, and Tag` #DS-2705) was intentionally left out of the notes per the release-notes skill's filtering rules — flagging here for visibility before merge.

## Test plan
- [ ] Review generated content against the actual changelogs before pasting into Slack Canvas