### PR TITLE
ci(repo): configure Figma asset sync from GitHub environment

### DIFF
--- a/.github/workflows/figma-icons-sync.yaml
+++ b/.github/workflows/figma-icons-sync.yaml
@@ -51,25 +51,20 @@ jobs:
         env:
           FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
           FIGMA_FILE_KEY: UMd06VnGrAE5xheb4C8QEg
+          DISPATCH_DESCRIPTION: ${{ github.event.client_payload.description }}
         run: |
-          NOTES=""
-          if RESPONSE="$(curl -fsS -H "X-Figma-Token: ${FIGMA_ACCESS_TOKEN}" \
-            "https://api.figma.com/v1/files/${FIGMA_FILE_KEY}/versions")"; then
-            NOTES="$(printf '%s' "$RESPONSE" | node --input-type=module -e '
-              const chunks = [];
-              process.stdin.on("data", (chunk) => chunks.push(chunk));
-              process.stdin.on("end", () => {
-                try {
-                  const json = JSON.parse(Buffer.concat(chunks).toString("utf8"));
-                  const description = json?.versions?.[0]?.description;
-                  if (typeof description === "string" && description.trim()) {
-                    process.stdout.write(description.trim());
-                  }
-                } catch {
-                  // Missing or invalid version metadata must not fail the sync.
-                }
-              });
-            ')" || true
+          NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter publish-notes)"
+
+          if [ -z "$NOTES" ]; then
+            HTTP_CODE="$(curl -sS -o /tmp/figma-versions.json -w '%{http_code}' \
+              -H "X-Figma-Token: ${FIGMA_ACCESS_TOKEN}" \
+              "https://api.figma.com/v1/files/${FIGMA_FILE_KEY}/versions" || true)"
+
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "::warning::Figma versions API returned HTTP ${HTTP_CODE}. Grant file_versions:read on FIGMA_ACCESS_TOKEN, or forward the library publish description as repository_dispatch client_payload.description."
+            else
+              NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter publish-notes /tmp/figma-versions.json)"
+            fi
           fi
 
           {

--- a/.github/workflows/figma-icons-sync.yaml
+++ b/.github/workflows/figma-icons-sync.yaml
@@ -18,6 +18,7 @@ jobs:
       (github.event.action == 'figma-library-publish' &&
       github.event.client_payload.file_key == 'UMd06VnGrAE5xheb4C8QEg')
     runs-on: ubuntu-24.04
+    environment: figma
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/figma-icons-sync.yaml
+++ b/.github/workflows/figma-icons-sync.yaml
@@ -11,17 +11,43 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-figma-file:
+    name: Check Figma file
+    runs-on: ubuntu-24.04
+    environment: figma
+    timeout-minutes: 5
+    env:
+      FIGMA_FILE_KEY: ${{ vars.FIGMA_FILE_KEY }}
+    outputs:
+      matched: ${{ steps.file-key.outputs.matched }}
+
+    steps:
+      - name: Check Figma file key
+        id: file-key
+        env:
+          DISPATCH_FILE_KEY: ${{ github.event.client_payload.file_key }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          MATCHED=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] || [ "$DISPATCH_FILE_KEY" = "$FIGMA_FILE_KEY" ]; then
+            MATCHED=true
+          fi
+          echo "matched=$MATCHED" >> "$GITHUB_OUTPUT"
+          if [ "$MATCHED" = "false" ]; then
+            echo "Skipping sync: published Figma file does not match this repository."
+          fi
+
   sync:
     name: Sync Figma Assets
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'figma-library-publish' &&
-      github.event.client_payload.file_key == 'UMd06VnGrAE5xheb4C8QEg')
+    needs: check-figma-file
+    if: ${{ needs.check-figma-file.outputs.matched == 'true' }}
     runs-on: ubuntu-24.04
     environment: figma
     timeout-minutes: 15
     permissions:
       contents: read
+    env:
+      FIGMA_FILE_KEY: ${{ vars.FIGMA_FILE_KEY }}
 
     steps:
       - name: Generate GitHub App token
@@ -50,10 +76,9 @@ jobs:
         id: figma-notes
         env:
           FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
-          FIGMA_FILE_KEY: UMd06VnGrAE5xheb4C8QEg
           DISPATCH_DESCRIPTION: ${{ github.event.client_payload.description }}
         run: |
-          NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter publish-notes)"
+          NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter read-publish-notes)"
 
           if [ -z "$NOTES" ]; then
             HTTP_CODE="$(curl -sS -o /tmp/figma-versions.json -w '%{http_code}' \
@@ -63,7 +88,7 @@ jobs:
             if [ "$HTTP_CODE" != "200" ]; then
               echo "::warning::Figma versions API returned HTTP ${HTTP_CODE}. Grant file_versions:read on FIGMA_ACCESS_TOKEN, or forward the library publish description as repository_dispatch client_payload.description."
             else
-              NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter publish-notes /tmp/figma-versions.json)"
+              NOTES="$(yarn workspace @alma-oss/spirit-assets-exporter read-publish-notes /tmp/figma-versions.json)"
             fi
           fi
 

--- a/apps/demo/netlify.toml
+++ b/apps/demo/netlify.toml
@@ -33,5 +33,6 @@ ignore = """\
     ./packages/web-react/ \
     ./apps/demo/ \
     ./packages/web/ \
+    ./packages/icons/ \
     ./.github/workflows/ \
     """

--- a/apps/storybook/netlify.toml
+++ b/apps/storybook/netlify.toml
@@ -34,6 +34,7 @@ ignore = """\
     ./packages/web-react/src/ \
     ./apps/storybook/ \
     ./packages/web-react/docs/stories/ \
+    ./packages/icons/ \
     """
 
 [[headers]]

--- a/exporters/assets/README.md
+++ b/exporters/assets/README.md
@@ -97,7 +97,8 @@ The sync aborts before changing a target when it cannot discover or download the
 This repository runs the **Sync Assets** GitHub Actions workflow. It accepts a manual `workflow_dispatch` or a
 `figma-library-publish` repository dispatch. An external automation such as Make can receive Figma's `LIBRARY_PUBLISH`
 webhook and send that dispatch. The workflow reuses the branch `chore/figma-icons-sync` so a rerun updates the same pull
-request. When Figma publish notes are available on the latest file version, they are added to the pull request body.
+request. When Figma publish notes are available on the latest file version, they are added to the pull request body. The
+job runs in the `figma` GitHub Actions environment, which holds the `FIGMA_ACCESS_TOKEN` secret.
 
 Other repositories can copy this workflow:
 
@@ -113,6 +114,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-24.04
+    environment: figma
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-install

--- a/exporters/assets/README.md
+++ b/exporters/assets/README.md
@@ -69,8 +69,8 @@ Illustrations should use a separate target because they are not part of the 24×
 
 ## Usage
 
-Set `FIGMA_ACCESS_TOKEN` to a Figma personal access token with `file_content:read` (and `file_versions:read` if the
-workflow should read publish notes from Figma version history) and access to the Asset File, then run:
+Set `FIGMA_ACCESS_TOKEN` to a Figma personal access token with `file_content:read` and access to the Asset File, then
+run:
 
 ```shell
 yarn icons:sync
@@ -94,40 +94,11 @@ The sync aborts before changing a target when it cannot discover or download the
 
 ## Automated Delivery
 
-This repository runs the **Sync Assets** GitHub Actions workflow. It accepts a manual `workflow_dispatch` or a
-`figma-library-publish` repository dispatch. An external automation such as Make can receive Figma's `LIBRARY_PUBLISH`
-webhook and send that dispatch. The workflow reuses the branch `chore/figma-icons-sync` so a rerun updates the same pull
-request. Publish notes come from `client_payload.description` on the dispatch, then from Figma version history when the
-token has `file_versions:read`. The job runs in the `figma` GitHub Actions environment, which holds the
-`FIGMA_ACCESS_TOKEN` secret.
+This repository runs a GitHub Actions workflow that synchronizes icons from Figma. It can be started manually or by a
+Figma library publish via external automation. Credentials live in GitHub Actions. The workflow opens or updates a pull
+request when the generated SVGs differ.
 
-Other repositories can copy this workflow:
-
-```yaml
-name: Sync Assets
-
-on:
-  workflow_dispatch:
-  repository_dispatch:
-    types:
-      - figma-library-publish
-
-jobs:
-  sync:
-    runs-on: ubuntu-24.04
-    environment: figma
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/setup-install
-      - run: yarn icons:sync
-        env:
-          FIGMA_ACCESS_TOKEN: ${{ secrets.FIGMA_ACCESS_TOKEN }}
-      - uses: peter-evans/create-pull-request@v8
-        with:
-          branch: chore/figma-icons-sync
-          commit-message: 'chore(icons): sync icons from Figma'
-          title: 'Chore(icons): Sync icons from Figma'
-```
+Other repositories can set up a similar workflow to run the CLI and open a pull request.
 
 Cyborg delivery is planned, not implemented: configuration stays in this repository, and a GitHub Action would open a
 commit and pull request in Cyborg. Until then, Cyborg does not run this CLI.

--- a/exporters/assets/README.md
+++ b/exporters/assets/README.md
@@ -69,8 +69,8 @@ Illustrations should use a separate target because they are not part of the 24×
 
 ## Usage
 
-Set `FIGMA_ACCESS_TOKEN` to a Figma personal access token with the `file_content:read` scope and access to the Asset
-File, then run:
+Set `FIGMA_ACCESS_TOKEN` to a Figma personal access token with `file_content:read` (and `file_versions:read` if the
+workflow should read publish notes from Figma version history) and access to the Asset File, then run:
 
 ```shell
 yarn icons:sync
@@ -97,8 +97,9 @@ The sync aborts before changing a target when it cannot discover or download the
 This repository runs the **Sync Assets** GitHub Actions workflow. It accepts a manual `workflow_dispatch` or a
 `figma-library-publish` repository dispatch. An external automation such as Make can receive Figma's `LIBRARY_PUBLISH`
 webhook and send that dispatch. The workflow reuses the branch `chore/figma-icons-sync` so a rerun updates the same pull
-request. When Figma publish notes are available on the latest file version, they are added to the pull request body. The
-job runs in the `figma` GitHub Actions environment, which holds the `FIGMA_ACCESS_TOKEN` secret.
+request. Publish notes come from `client_payload.description` on the dispatch, then from Figma version history when the
+token has `file_versions:read`. The job runs in the `figma` GitHub Actions environment, which holds the
+`FIGMA_ACCESS_TOKEN` secret.
 
 Other repositories can copy this workflow:
 

--- a/exporters/assets/package.json
+++ b/exporters/assets/package.json
@@ -21,6 +21,7 @@
     "build:compile": "vite build",
     "lint": "eslint ./",
     "lint:fix": "yarn lint --fix",
+    "read-publish-notes": "tsx ./src/bin/read-publish-notes.ts",
     "sync": "tsx ./src/bin/spirit-assets.js sync",
     "test": "npm-run-all --serial lint types build test:unit:coverage",
     "test:unit": "jest",

--- a/exporters/assets/src/__tests__/publishNotes.test.ts
+++ b/exporters/assets/src/__tests__/publishNotes.test.ts
@@ -1,0 +1,34 @@
+import { extractPublishNotesFromDispatch, extractPublishNotesFromVersions } from '../adapters/figma/publishNotes';
+
+describe('extractPublishNotesFromDispatch', () => {
+  it('reads the library publish description from the repository_dispatch payload', () => {
+    expect(extractPublishNotesFromDispatch({ description: 'Update', file_key: 'abc' })).toBe('Update');
+  });
+
+  it.each([undefined, null, '', '   ', 1, {}, []])('ignores missing or invalid payload notes: %p', (payload) => {
+    expect(extractPublishNotesFromDispatch(payload)).toBe('');
+    expect(extractPublishNotesFromDispatch({ description: payload })).toBe('');
+  });
+});
+
+describe('extractPublishNotesFromVersions', () => {
+  it('uses the first version with a description or label', () => {
+    expect(
+      extractPublishNotesFromVersions({
+        versions: [
+          { created_at: '2026-09-08T07:58:00Z', description: '', label: null },
+          { created_at: '2026-09-08T07:57:00Z', description: 'Update', label: 'Autosave' },
+        ],
+      }),
+    ).toBe('Update');
+  });
+
+  it('falls back to the version label when description is empty', () => {
+    expect(extractPublishNotesFromVersions({ versions: [{ description: ' ', label: 'Update' }] })).toBe('Update');
+  });
+
+  it('returns nothing when the versions payload is missing or empty', () => {
+    expect(extractPublishNotesFromVersions({ versions: [] })).toBe('');
+    expect(extractPublishNotesFromVersions({ err: 'Invalid token' })).toBe('');
+  });
+});

--- a/exporters/assets/src/__tests__/publishNotes.test.ts
+++ b/exporters/assets/src/__tests__/publishNotes.test.ts
@@ -31,4 +31,16 @@ describe('extractPublishNotesFromVersions', () => {
     expect(extractPublishNotesFromVersions({ versions: [] })).toBe('');
     expect(extractPublishNotesFromVersions({ err: 'Invalid token' })).toBe('');
   });
+
+  it.each([undefined, null, '', '   ', 1, {}, []])('ignores missing or invalid versions payloads: %p', (payload) => {
+    expect(extractPublishNotesFromVersions(payload)).toBe('');
+  });
+
+  it('skips version entries that are not objects', () => {
+    expect(
+      extractPublishNotesFromVersions({
+        versions: [null, 'skip', [], { description: 'Update' }],
+      }),
+    ).toBe('Update');
+  });
 });

--- a/exporters/assets/src/adapters/figma/publishNotes.ts
+++ b/exporters/assets/src/adapters/figma/publishNotes.ts
@@ -1,0 +1,46 @@
+const firstNonEmptyNote = (...values: unknown[]): string => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return '';
+};
+
+export const extractPublishNotesFromDispatch = (payload: unknown): string => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return '';
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  return firstNonEmptyNote(record.description, record.label);
+};
+
+export const extractPublishNotesFromVersions = (payload: unknown): string => {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return '';
+  }
+
+  const { versions } = payload as { versions?: unknown };
+
+  if (!Array.isArray(versions)) {
+    return '';
+  }
+
+  for (const version of versions) {
+    if (!version || typeof version !== 'object' || Array.isArray(version)) {
+      continue;
+    }
+
+    const record = version as Record<string, unknown>;
+    const note = firstNonEmptyNote(record.description, record.label);
+
+    if (note) {
+      return note;
+    }
+  }
+
+  return '';
+};

--- a/exporters/assets/src/bin/read-publish-notes.ts
+++ b/exporters/assets/src/bin/read-publish-notes.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+
+import { extractPublishNotesFromDispatch, extractPublishNotesFromVersions } from '../adapters/figma/publishNotes';
+
+const dispatchNotes = extractPublishNotesFromDispatch({
+  description: process.env.DISPATCH_DESCRIPTION,
+});
+
+if (dispatchNotes) {
+  process.stdout.write(dispatchNotes);
+  process.exit(0);
+}
+
+const versionsPath = process.argv[2];
+
+if (!versionsPath) {
+  process.exit(0);
+}
+
+process.stdout.write(extractPublishNotesFromVersions(JSON.parse(readFileSync(versionsPath, 'utf8'))));

--- a/exporters/assets/vite.config.ts
+++ b/exporters/assets/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     externalizeDeps(),
     dts({
-      exclude: ['**/__tests__/**', '**/__fixtures__/**'],
+      exclude: ['**/__tests__/**', '**/__fixtures__/**', '**/bin/**'],
       insertTypesEntry: true,
       rollupTypes: false,
     }),

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -115,9 +115,9 @@ FIGMA_ACCESS_TOKEN=your-token yarn icons:sync
 The command adds, updates, and deletes SVGs so the directory exactly matches Figma. It does not rewrite icon colors;
 color normalization remains part of the package build.
 
-Maintainers can run the **Sync Assets** workflow from GitHub Actions. The job uses the `figma` environment for
-`FIGMA_ACCESS_TOKEN`. An external automation such as Make can also start the same workflow after a Figma
-`LIBRARY_PUBLISH` event. It opens or updates a pull request when the generated SVGs differ.
+Maintainers can run the **Sync Assets** workflow from GitHub Actions. It can be started manually or by a Figma library
+publish via external automation. Credentials live in GitHub Actions. The workflow opens or updates a pull request when
+the generated SVGs differ.
 
 [esm-only]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 [figma-assets]: https://www.figma.com/design/UMd06VnGrAE5xheb4C8QEg/Assets

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -115,9 +115,9 @@ FIGMA_ACCESS_TOKEN=your-token yarn icons:sync
 The command adds, updates, and deletes SVGs so the directory exactly matches Figma. It does not rewrite icon colors;
 color normalization remains part of the package build.
 
-Maintainers can run the **Sync Assets** workflow from GitHub Actions. An external automation such as Make can
-also start the same workflow after a Figma `LIBRARY_PUBLISH` event. It opens or updates a pull request when the
-generated SVGs differ.
+Maintainers can run the **Sync Assets** workflow from GitHub Actions. The job uses the `figma` environment for
+`FIGMA_ACCESS_TOKEN`. An external automation such as Make can also start the same workflow after a Figma
+`LIBRARY_PUBLISH` event. It opens or updates a pull request when the generated SVGs differ.
 
 [esm-only]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
 [figma-assets]: https://www.figma.com/design/UMd06VnGrAE5xheb4C8QEg/Assets


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

The Sync Assets workflow still read Figma credentials from repository secrets and hardcoded the Assets file key, so it could not reuse the existing `figma` environment, stay repo-agnostic, or surface Figma publish notes on the generated PR. The job now runs in that environment, matches `FIGMA_FILE_KEY` from GitHub variables, and extracts notes through the assets exporter (dispatch payload first, then the versions API). Docs were generalized for other consumers, and demo/Storybook deploy-previews now build when `packages/icons` changes.

### Additional context

`GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY` stay as repository secrets; `FIGMA_ACCESS_TOKEN` (secret) and `FIGMA_FILE_KEY` (variable) live in the `figma` environment, matching `environment: npm-registry` in Publish.

If the token lacks `file_versions:read`, the workflow warns and still opens the sync PR; forward `client_payload.description` from the library-publish dispatch to keep notes without that scope.

Depends on the `figma` environment already existing in repository settings.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->