### PR TITLE
fix(web): raise `UNSTABLE_Combobox` stacking when popover is open

### DIFF
--- a/packages/web/src/scss/components/InputContainer/_InputContainer.scss
+++ b/packages/web/src/scss/components/InputContainer/_InputContainer.scss
@@ -1,13 +1,9 @@
 // 1. Create a stacking context so that ControlButtons inside Tags (z-index: 1) do not escape
 //    into the page stacking context and overlap DropdownPopovers of neighboring Pickers.
 // 2. For select, we need to place the input addon over the input to keep the interaction consistent.
-// 3. When a nested DropdownPopover opens inside the field (e.g. SplitTag distance menu in Combobox),
-//    raise this stacking context so the popover paints above the next InputContainer. Nested
-//    popovers cannot escape `isolation: isolate` on their own; the Combobox options popover
-//    avoids this by living as a sibling of InputContainer.
-// 4. We pass the input arrows width if the input type is number.
-// 5. If the input has a size attribute, we calculate the width based on the input width, padding, border width and arrows width.
-// 6. We generate the input width based on the number of characters.
+// 3. We pass the input arrows width if the input type is number.
+// 4. If the input has a size attribute, we calculate the width based on the input width, padding, border width and arrows width.
+// 5. We generate the input width based on the number of characters.
 
 @use '@tokens' as tokens;
 @use '../../settings/cursors';
@@ -61,11 +57,6 @@
         box-shadow: theme.$focus-shadow;
     }
 
-    // 3. After lower-specificity `&:has` / `&:focus-within` rules (stylelint no-descending-specificity).
-    &:has(.DropdownPopover.is-open) {
-        z-index: 1;
-    }
-
     @media (hover: hover) {
         &:not(.InputContainer--disabled):hover {
             background-color: var(--#{tokens.$css-variable-prefix}input-container-background-color-state-hover);
@@ -115,12 +106,12 @@
 .InputContainer > input {
     padding-block: theme.$input-padding-y;
 
-    // 4.
+    // 3.
     &:where([type='number']) {
         --#{tokens.$css-variable-prefix}input-container-input-arrows-width: #{theme.$input-number-arrows-width};
     }
 
-    // 5.
+    // 4.
     &:where([size]) {
         width: calc(
             var(--#{tokens.$css-variable-prefix}input-container-input-width) + 2 *
@@ -130,7 +121,7 @@
         );
     }
 
-    // 6.
+    // 5.
     @each $size in theme.$input-size-characters {
         &:where([size='#{$size}']) {
             --#{tokens.$css-variable-prefix}input-container-input-width: #{$size}ch;

--- a/packages/web/src/scss/components/UNSTABLE_Combobox/_UNSTABLE_Combobox.scss
+++ b/packages/web/src/scss/components/UNSTABLE_Combobox/_UNSTABLE_Combobox.scss
@@ -1,10 +1,18 @@
 // 1. Sized to comfortably fit the default placeholder copy ("+ Add more…", ~11 characters).
+// 2. Temporary stacking workaround until Dropdown uses the Popover API top layer.
+//    @see https://developer.mozilla.org/en-US/docs/Web/API/Popover_API
 
 @use '@tokens' as tokens;
 @use 'theme';
 
 .UNSTABLE_Combobox {
     --#{tokens.$css-variable-prefix}combobox-input-min-width: #{theme.$input-min-width};
+}
+
+// 2.
+.UNSTABLE_Combobox:has(.DropdownPopover.is-open) {
+    position: relative;
+    z-index: 2;
 }
 
 .UNSTABLE_Combobox__input {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Description

An open `UNSTABLE_Combobox` options popover painted under later form controls (checkboxes and radios use `z-index: 1`). Nested SplitTag already lifts `InputContainer` when it contains an open popover, but the Combobox options panel is a sibling of `InputContainer`, so that rule never applied. This raises `.UNSTABLE_Combobox` to `z-index: 2` while any `DropdownPopover` is open — above inline field inputs, same `:has()` pattern, until popovers can use the top layer.

https://github.com/user-attachments/assets/47f504ef-0af0-4ef8-9e22-b8ad69b804bd

### Issue reference

https://jira.almacareer.tech/browse/DS-2771