### PR TITLE
ci: fall back to run URL when no artifact was uploaded

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,7 +171,7 @@ jobs:
                             "type": "plain_text",
                             "text": ":github: Download Report"
                           },
-                          "url": "${{ steps.artifact-upload-step.outputs.artifact-url }}"
+                          "url": "${{ steps.artifact-upload-step.outputs.artifact-url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}"
                         }
                       ]
                     }


### PR DESCRIPTION
## Description

The E2E workflow's failure-notification Slack step used the uploaded Playwright report's artifact URL for its "Download Report" button. When the job fails before Playwright ever runs (e.g. the Netlify preview deploy times out), no report artifact exists, so that URL is empty — and Slack's Block Kit rejects a button with an empty `url`, causing the whole notification to fail silently (`400 invalid_attachments`). This meant nobody was actually alerted when E2E failed for that reason.

Falls back to the GitHub Actions run URL when no artifact was produced, so the notification always sends.

### Additional context

Found while investigating https://github.com/alma-oss/spirit-design-system/actions/runs/34601292037/job/103268995946 (PR #2928) — that job's actual failure was an unrelated Netlify deploy race/cancellation, but it exposed this notification bug as a side effect.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->