### PR TITLE
chore(deps): switch browserslist, remark, and stylelint configs to `@alma-oss` scope

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -102,6 +102,9 @@ Caddyfile
 # Node version
 .nvmrc
 
+# Browserslist config (no Prettier parser for this format)
+.browserslistrc
+
 # Git
 .gitignore
 .gitattributes

--- a/.remarkrc.mjs
+++ b/.remarkrc.mjs
@@ -1,4 +1,4 @@
-import config from '@almacareer/remark-config';
+import config from '@alma-oss/remark-config';
 
 export default {
   ...config,

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -130,7 +130,7 @@ catalogs:
     autoprefixer: 10.5.4
     postcss-preset-env: 10.6.1
     clean-css-cli: 5.6.3
-    '@lmc-eu/browserslist-config': 2.0.1
+    '@alma-oss/browserslist-config': 3.0.0-alpha.0
     vite-plugin-handlebars: 2.0.3
     handlebars: 4.7.9
     vite-raw-plugin: 1.0.2
@@ -176,8 +176,8 @@ catalogs:
     remark-cli: 12.0.1
     remark-frontmatter: 5.0.0
     remark-lint-heading-capitalization: 1.3.0
-    '@almacareer/remark-config': 0.1.0
-    '@almacareer/stylelint-config': 9.1.3
+    '@alma-oss/remark-config': 1.0.0-alpha.0
+    '@alma-oss/stylelint-config': 10.0.0-alpha.0
     '@lmc-eu/eslint-config-base': 3.1.3
     '@lmc-eu/eslint-config-react': 2.0.6
     '@lmc-eu/eslint-config-typescript': 2.1.5

--- a/configs/stylelint-config-spirit/index.js
+++ b/configs/stylelint-config-spirit/index.js
@@ -3,5 +3,5 @@ import styleRules from './rules/style.js';
 import unstableRules from './rules/unstable.js';
 
 export default {
-  extends: ['@almacareer/stylelint-config', prettierPlugin, styleRules, unstableRules],
+  extends: ['@alma-oss/stylelint-config', prettierPlugin, styleRules, unstableRules],
 };

--- a/configs/stylelint-config-spirit/package.json
+++ b/configs/stylelint-config-spirit/package.json
@@ -26,7 +26,7 @@
     "stylelint": "^16.0.0"
   },
   "dependencies": {
-    "@almacareer/stylelint-config": "catalog:lint",
+    "@alma-oss/stylelint-config": "catalog:lint",
     "prettier": "catalog:lint",
     "stylelint": "catalog:lint",
     "stylelint-order": "catalog:lint",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@alma-oss/commitlint-config": "catalog:lint",
-    "@almacareer/remark-config": "catalog:lint",
+    "@alma-oss/remark-config": "catalog:lint",
     "@axe-core/playwright": "catalog:test",
     "@commitlint/cli": "catalog:lint",
     "@eslint/compat": "catalog:lint",

--- a/packages/web-react/docs/stories/examples/CvBuilderPublish.stories.tsx
+++ b/packages/web-react/docs/stories/examples/CvBuilderPublish.stories.tsx
@@ -1,0 +1,391 @@
+import React, { useMemo, useState } from 'react';
+import {
+  ActionGroup,
+  Box,
+  Breadcrumbs,
+  Button,
+  Checkbox,
+  ControlButton,
+  FieldGroup,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  Icon,
+  InputAddon,
+  Label,
+  Radio,
+  Section,
+  Select,
+  Slider,
+  Stack,
+  StackItem,
+  Text,
+  TextField,
+  Tooltip,
+  TooltipPopover,
+  TooltipTrigger,
+  UNSTABLE_Combobox,
+  UNSTABLE_ComboboxOption,
+  VisuallyHidden,
+} from '../../../src/components';
+import { useToggle } from '../../../src/hooks';
+
+export default {
+  title: 'Examples/Pages',
+  parameters: { layout: 'fullscreen' },
+};
+
+type SalaryType = 'unspecified' | 'specific';
+type StartDateType = 'unspecified' | 'immediately' | 'after-notice' | 'specific';
+
+const SALARY_MIN = 0;
+const SALARY_MAX = 200000;
+const SALARY_STEP = 5000;
+
+const formatSalary = (n: number) => Math.round(n).toString();
+
+const parseSalary = (s: string) => {
+  const digits = s.replace(/\D/g, '');
+
+  return digits === '' ? 0 : Math.min(parseInt(digits, 10), SALARY_MAX);
+};
+
+const JOB_OPTIONS = [
+  { id: 'developer', label: 'Vývojář' },
+  { id: 'designer', label: 'Designer' },
+  { id: 'manager', label: 'Manažer' },
+  { id: 'analyst', label: 'Analytik' },
+  { id: 'tester', label: 'Tester' },
+];
+
+const LOCATION_OPTIONS = [
+  { id: 'prague', label: 'Praha' },
+  { id: 'brno', label: 'Brno' },
+  { id: 'ostrava', label: 'Ostrava' },
+  { id: 'jihlava', label: 'Jihlava' },
+  { id: 'liberec', label: 'Liberec' },
+];
+
+export const CvBuilderPublish = () => {
+  const [salaryType, setSalaryType] = useState<SalaryType>('unspecified');
+  const [startDateType, setStartDateType] = useState<StartDateType>('unspecified');
+  const [salaryValue, setSalaryValue] = useState(50000);
+  const [isHideTooltipOpen, setIsHideTooltipOpen] = useState(false);
+
+  const [isJobOpen, onJobToggle] = useToggle(false);
+  const [jobSelectedKeys, setJobSelectedKeys] = useState<string[]>([]);
+  const [jobInputValue, setJobInputValue] = useState('');
+
+  const [isLocationOpen, onLocationToggle] = useToggle(false);
+  const [locationSelectedKeys, setLocationSelectedKeys] = useState<string[]>([]);
+  const [locationInputValue, setLocationInputValue] = useState('');
+
+  const [isHideCompaniesOpen, onHideCompaniesToggle] = useToggle(false);
+  const [hideCompaniesSelectedKeys, setHideCompaniesSelectedKeys] = useState<string[]>([]);
+  const [hideCompaniesInputValue, setHideCompaniesInputValue] = useState('');
+
+  const filteredJobOptions = useMemo(() => {
+    const query = jobInputValue.trim().toLowerCase();
+
+    return JOB_OPTIONS.filter((option) => option.label.toLowerCase().includes(query));
+  }, [jobInputValue]);
+
+  const filteredLocationOptions = useMemo(() => {
+    const query = locationInputValue.trim().toLowerCase();
+
+    return LOCATION_OPTIONS.filter((option) => option.label.toLowerCase().includes(query));
+  }, [locationInputValue]);
+
+  // @ts-ignore
+  // @ts-ignore
+  return (
+    <>
+      <Section elementType="div" containerProps={{ size: 'large' }} paddingTop="space-1000">
+        <Stack spacing="space-1000">
+          <Breadcrumbs
+            goBackTitle="Zpět"
+            items={[
+              { title: 'Můj Jobs.cz', url: '#' },
+              { title: 'Životopis', url: '#' },
+              { title: 'Vystavit životopis' },
+            ]}
+          />
+          <Heading id="publish-cv-heading" elementType="h1" size="large" fontWeight="semibold" marginBottom="space-0">
+            Jakým firmám se má váš životopis zobrazovat
+          </Heading>
+          <Text marginBottom="space-0">
+            Zadejte obor, ve kterém chcete pracovat, lokalitu, úvazek a mzdu. Můžete si také nastavit, které firmy váš
+            životopis vidět nemají.
+          </Text>
+        </Stack>
+      </Section>
+      <Section elementType="div" size="small" containerProps={{ size: 'large' }}>
+        {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
+                and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
+        <Stack elementType="form" action="#" method="post" aria-labelledby="publish-cv-heading" spacing="space-1000">
+          <Box
+            backgroundColor="primary"
+            borderColor="basic"
+            borderRadius="400"
+            borderWidth="100"
+            paddingX="space-800"
+            paddingY="space-900"
+          >
+            <Stack hasIntermediateDividers spacing="space-900">
+              <StackItem>
+                <Stack spacing="space-700">
+                  {/* TODO: DS-2771 — Combobox popover needs z-index when it's open to be in front of another nodes with higher z-index */}
+                  <UNSTABLE_Combobox
+                    id="publish-job-search"
+                    label="Jakou práci hledáte?"
+                    emptySelectionLabel="Zadejte obor, profesi,…"
+                    isRequired
+                    isOpen={isJobOpen}
+                    onToggle={onJobToggle}
+                    selectedKeys={jobSelectedKeys}
+                    onSelectionChange={setJobSelectedKeys}
+                    inputValue={jobInputValue}
+                    onInputChange={setJobInputValue}
+                    optionKeys={JOB_OPTIONS.map((o) => o.id)}
+                    hasEmptyState={filteredJobOptions.length === 0}
+                  >
+                    {filteredJobOptions.map((option) => (
+                      <UNSTABLE_ComboboxOption key={option.id} value={option.id}>
+                        <Label>{option.label}</Label>
+                      </UNSTABLE_ComboboxOption>
+                    ))}
+                  </UNSTABLE_Combobox>
+                  <UNSTABLE_Combobox
+                    id="publish-location-search"
+                    label="Ve kterém městě nebo kraji chcete pracovat?"
+                    emptySelectionLabel="Jihlava"
+                    isRequired
+                    isOpen={isLocationOpen}
+                    onToggle={onLocationToggle}
+                    selectedKeys={locationSelectedKeys}
+                    onSelectionChange={setLocationSelectedKeys}
+                    inputValue={locationInputValue}
+                    onInputChange={setLocationInputValue}
+                    optionKeys={LOCATION_OPTIONS.map((o) => o.id)}
+                    hasEmptyState={filteredLocationOptions.length === 0}
+                  >
+                    {filteredLocationOptions.map((option) => (
+                      <UNSTABLE_ComboboxOption key={option.id} value={option.id}>
+                        <Label>{option.label}</Label>
+                      </UNSTABLE_ComboboxOption>
+                    ))}
+                  </UNSTABLE_Combobox>
+                  <Checkbox id="publish-remote" name="remote" label="Chci pracovat z domova (remote)" />
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <FieldGroup id="publish-job-type" label="Jaký typ úvazku preferujete?" isRequired>
+                  <Checkbox id="publish-job-type-full" name="jobType" label="Plný" />
+                  <Checkbox id="publish-job-type-part" name="jobType" label="Zkrácený" />
+                </FieldGroup>
+              </StackItem>
+
+              <StackItem>
+                <Stack spacing="space-800">
+                  <FieldGroup id="publish-salary" label="Očekávaná hrubá mzda">
+                    <Radio
+                      id="publish-salary-unspecified"
+                      name="salary"
+                      label="Neurčeno"
+                      isChecked={salaryType === 'unspecified'}
+                      onChange={() => setSalaryType('unspecified')}
+                    />
+                    <Radio
+                      id="publish-salary-gross"
+                      name="salary"
+                      label="Zadám hrubou mzdu"
+                      isChecked={salaryType === 'specific'}
+                      {...(salaryType === 'specific' && {
+                        'aria-controls': 'publish-salary-amount',
+                      })}
+                      onChange={() => setSalaryType('specific')}
+                    />
+                  </FieldGroup>
+                  {salaryType === 'specific' && (
+                    <Grid cols={{ mobile: 1, tablet: 2, desktop: 4 }}>
+                      <GridItem>
+                        <Stack spacing="space-800">
+                          <TextField
+                            id="publish-salary-amount"
+                            label="Hrubá mzda od"
+                            value={formatSalary(salaryValue)}
+                            onChange={(e) => setSalaryValue(parseSalary(e.target.value))}
+                            endAddon={<InputAddon>Kč</InputAddon>}
+                            min={SALARY_MIN}
+                            max={SALARY_MAX}
+                            type="number"
+                            aria-labelledby="publish-salary-gross"
+                          />
+                          <Slider
+                            id="publish-salary-slider"
+                            label="Hrubá mzda"
+                            isLabelHidden
+                            min={SALARY_MIN}
+                            max={SALARY_MAX}
+                            step={SALARY_STEP}
+                            value={salaryValue}
+                            onChange={(e) => setSalaryValue(Number(e.target.value))}
+                            // We are hiding `Slider` for assistive technologies because
+                            // it shared the same value as `TextField`. Moreover the `TextField`
+                            // should be much easier for users to control than `Slider`.
+                            aria-hidden="true"
+                          />
+                        </Stack>
+                      </GridItem>
+                    </Grid>
+                  )}
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <Stack spacing="space-700">
+                  <FieldGroup id="publish-start-date" label="Kdy můžete nastoupit?">
+                    <Radio
+                      id="publish-start-unspecified"
+                      name="startDate"
+                      label="Neurčeno"
+                      isChecked={startDateType === 'unspecified'}
+                      onChange={() => setStartDateType('unspecified')}
+                    />
+                    <Radio
+                      id="publish-start-immediately"
+                      name="startDate"
+                      label="Okamžitě"
+                      isChecked={startDateType === 'immediately'}
+                      onChange={() => setStartDateType('immediately')}
+                    />
+                    <Radio
+                      id="publish-start-notice"
+                      name="startDate"
+                      label="Po uplynutí výpovědní doby"
+                      isChecked={startDateType === 'after-notice'}
+                      onChange={() => setStartDateType('after-notice')}
+                    />
+                    <Radio
+                      id="publish-start-date-specific"
+                      name="startDate"
+                      label="Zadám přesné datum"
+                      isChecked={startDateType === 'specific'}
+                      {...(startDateType === 'specific' && {
+                        'aria-controls': 'publish-start-month publish-start-year',
+                      })}
+                      onChange={() => setStartDateType('specific')}
+                    />
+                  </FieldGroup>
+                  {startDateType === 'specific' && (
+                    <Flex spacing="space-700" alignmentY="bottom">
+                      <Select
+                        id="publish-start-month"
+                        label="Datum nástupu"
+                        aria-labelledby="publish-start-date-specific"
+                      >
+                        <option value="1">Leden</option>
+                        <option value="2">Únor</option>
+                        <option value="3">Březen</option>
+                        <option value="4">Duben</option>
+                        <option value="5">Květen</option>
+                        <option value="6">Červen</option>
+                        <option value="7">Červenec</option>
+                        <option value="8">Srpen</option>
+                        <option value="9">Září</option>
+                        <option value="10">Říjen</option>
+                        <option value="11">Listopad</option>
+                        <option value="12">Prosinec</option>
+                      </Select>
+                      <Select id="publish-start-year" label="Rok" isLabelHidden>
+                        <option value="2025">2025</option>
+                        <option value="2026">2026</option>
+                        <option value="2027">2027</option>
+                      </Select>
+                    </Flex>
+                  )}
+                </Stack>
+              </StackItem>
+
+              <StackItem>
+                <FieldGroup id="publish-additional" label="Doplňující údaje">
+                  <Checkbox id="publish-ico" name="additional" label="Mohu pracovat na IČ" />
+                  <Checkbox id="publish-disability" name="additional" label="Jsem osoba se zdravotním postižením" />
+                </FieldGroup>
+              </StackItem>
+
+              <StackItem>
+                {/* TODO: DS-2771 — Combobox popover needs z-index when it's open to be in front of another nodes with higher z-index */}
+                {/* TODO: DS-2790 — label prop type is `string`; passing ReactNode causes
+                    TS2322: Type 'Element' is not assignable to type 'string'. Suppressed until fixed. */}
+                <UNSTABLE_Combobox
+                  id="publish-hide-companies"
+                  emptySelectionLabel="Uveďte název firmy"
+                  /* @ts-ignore – ReactNode isn't supported by the `label` -- @see https://jira.almacareer.tech/browse/DS-2790 */
+                  label={
+                    <>
+                      Chcete životopis skrýt před některými firmami?{' '}
+                      {/* TODO: DS-2773 — Vertical alignment should be handled by the component or label styles rather than UNSAFE_ overrides. */}
+                      <Tooltip
+                        elementType="span"
+                        id="publish-hide-tooltip"
+                        isOpen={isHideTooltipOpen}
+                        onToggle={setIsHideTooltipOpen}
+                        placement="top-start"
+                        aria-hidden="true"
+                        UNSAFE_style={{ verticalAlign: 'middle' }}
+                      >
+                        {/* TODO: DS-2772 — TooltipTrigger should set type="button" when elementType is a button to prevent accidental form submission. */}
+                        <ControlButton elementType={TooltipTrigger} type="button" isSymmetrical isSubtle size="small">
+                          <Icon name="info" />
+                          <VisuallyHidden>Více informací</VisuallyHidden>
+                        </ControlButton>
+                        <TooltipPopover id="publish-tooltip-popover">
+                          Když nechcete, aby některé firmy nebo organizace váš životopis viděly, zadejte jejich názvy.
+                          Hodí se to u firem, se kterými nemáte dobré zkušenosti, nebo třeba u současného
+                          zaměstnavatele.
+                        </TooltipPopover>
+                      </Tooltip>
+                    </>
+                  }
+                  isOpen={isHideCompaniesOpen}
+                  onToggle={onHideCompaniesToggle}
+                  selectedKeys={hideCompaniesSelectedKeys}
+                  onSelectionChange={setHideCompaniesSelectedKeys}
+                  inputValue={hideCompaniesInputValue}
+                  onInputChange={setHideCompaniesInputValue}
+                  optionKeys={[]}
+                  hasEmptyState={false}
+                  aria-describedby="publish-hide-companies-additional-info"
+                />
+                <VisuallyHidden id="publish-hide-companies-additional-info">
+                  Když nechcete, aby některé firmy nebo organizace váš životopis viděly, zadejte jejich názvy. Hodí se
+                  to u firem, se kterými nemáte dobré zkušenosti, nebo třeba u současného zaměstnavatele.
+                </VisuallyHidden>
+              </StackItem>
+              <StackItem>
+                <Stack spacing="space-900">
+                  <ActionGroup
+                    direction={{ mobile: 'vertical', tablet: 'horizontal' }}
+                    alignmentX={{ mobile: 'stretch', tablet: 'left' }}
+                    spacing="space-600"
+                  >
+                    <Button type="submit">Vystavit životopis</Button>
+                    <Button color="secondary">Zrušit</Button>
+                  </ActionGroup>
+                  <Text textColor="secondary">
+                    Vystavením životopisu zpřístupníte údaje personalistům, tj. našim klientům/zaměstnavatelům, kteří
+                    mají přístup do databáze životopisů. Personalisté z celé Evropy Vás budou moci najít v databázi
+                    podle Vámi zadaných informací/kritérií a budou Vás moci oslovit s pracovní nabídkou
+                  </Text>
+                </Stack>
+              </StackItem>
+            </Stack>
+          </Box>
+        </Stack>
+      </Section>
+    </>
+  );
+};

--- a/packages/web-react/docs/stories/examples/CvEditorDrivingLicense.stories.tsx
+++ b/packages/web-react/docs/stories/examples/CvEditorDrivingLicense.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ChangeEvent, useState } from 'react';
 import {
   ActionGroup,
   Box,
@@ -11,6 +11,10 @@ import {
   Heading,
   Section,
   Stack,
+  Toast,
+  ToastBar,
+  ToastBarMessage,
+  Toggle,
 } from '../../../src/components';
 
 const LICENSE_GROUPS = [
@@ -28,60 +32,115 @@ export default {
   parameters: { layout: 'fullscreen' },
 };
 
-export const CvEditorDrivingLicense = () => (
-  <>
-    <Section
-      elementType="div"
-      size="small"
-      backgroundColor="secondary"
-      containerProps={{ size: 'small' }}
-      paddingBottom={{ mobile: 'space-0', tablet: 'space-0' }}
-    >
-      <Stack spacing="space-1000">
-        <Breadcrumbs
-          goBackTitle="Zpět"
-          items={[{ title: 'Můj Jobs.cz', url: '#' }, { title: 'Životopis', url: '#' }, { title: 'Řidičský průkaz' }]}
-        />
-        <Heading
-          id="cv-driving-license-heading"
-          elementType="h1"
-          size="small"
-          fontWeight="semibold"
-          marginBottom="space-0"
+/**
+ * Interactive CV editor driving license page. The “Simulate validation errors” toggle puts the form
+ * into the state it has after a failed save — the license group in its `danger` state and the error
+ * Toast — so the error design can be reviewed without filling the form in.
+ */
+export const CvEditorDrivingLicense = () => {
+  const [hasSimulatedErrors, setHasSimulatedErrors] = useState(false);
+  const [isErrorToastOpen, setIsErrorToastOpen] = useState(false);
+
+  const handleSimulateErrorsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { checked } = event.target;
+
+    setHasSimulatedErrors(checked);
+    setIsErrorToastOpen(checked);
+  };
+
+  return (
+    <>
+      <Toast alignmentX="center" alignmentY="top">
+        <ToastBar
+          id="cv-driving-license-error-toast"
+          color="danger"
+          onClose={() => setIsErrorToastOpen(false)}
+          hasIcon
+          isDismissible
+          isOpen={isErrorToastOpen}
         >
-          Řidičský průkaz
-        </Heading>
-      </Stack>
-    </Section>
-    <Section elementType="div" size="small" backgroundColor="secondary" containerProps={{ size: 'small' }}>
-      <Stack
-        elementType="form"
-        onSubmit={(event) => event.preventDefault()}
-        aria-labelledby="cv-driving-license-heading"
-        spacing="space-1000"
-      >
-        {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
-              and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
-        <Box backgroundColor="primary" borderColor="basic" borderRadius="400" borderWidth="100" padding="space-900">
-          <FieldGroup id="cv-driving-license-groups" label="Skupiny řidičského průkazu" isLabelHidden>
-            <Grid cols={{ mobile: 1, tablet: 3 }} spacing="space-500">
-              {LICENSE_GROUPS.map(({ id, label }) => (
-                <GridItem key={id}>
-                  <Checkbox id={`cv-driving-license-${id}`} name="drivingLicense" value={id} label={label} />
-                </GridItem>
-              ))}
-            </Grid>
-          </FieldGroup>
+          <ToastBarMessage>Formulář se nepovedlo uložit. Zkontrolujte prosím zvýrazněná pole.</ToastBarMessage>
+        </ToastBar>
+      </Toast>
+      <Section elementType="div" size="small" containerProps={{ size: 'small' }}>
+        <Box
+          backgroundColor="emotion-informative-subtle"
+          borderColor="emotion-informative-basic"
+          borderWidth="100"
+          borderRadius="200"
+          padding="space-600"
+        >
+          <Toggle
+            id="cv-driving-license-simulate-errors"
+            label="Simulate validation errors"
+            isChecked={hasSimulatedErrors}
+            inputPosition="start"
+            onChange={handleSimulateErrorsChange}
+          />
         </Box>
-        <ActionGroup
-          direction={{ mobile: 'vertical', tablet: 'horizontal-reversed' }}
-          alignmentX={{ mobile: 'stretch', tablet: 'left' }}
-          spacing="space-600"
+      </Section>
+      <Section
+        elementType="div"
+        size="small"
+        backgroundColor="secondary"
+        containerProps={{ size: 'small' }}
+        paddingBottom={{ mobile: 'space-0', tablet: 'space-0' }}
+      >
+        <Stack spacing="space-1000">
+          <Breadcrumbs
+            goBackTitle="Zpět"
+            items={[{ title: 'Můj Jobs.cz', url: '#' }, { title: 'Životopis', url: '#' }, { title: 'Řidičský průkaz' }]}
+          />
+          <Heading
+            id="cv-driving-license-heading"
+            elementType="h1"
+            size="small"
+            fontWeight="semibold"
+            marginBottom="space-0"
+          >
+            Řidičský průkaz
+          </Heading>
+        </Stack>
+      </Section>
+      <Section elementType="div" size="small" backgroundColor="secondary" containerProps={{ size: 'small' }}>
+        <Stack
+          elementType="form"
+          onSubmit={(event) => event.preventDefault()}
+          aria-labelledby="cv-driving-license-heading"
+          spacing="space-1000"
+          noValidate
         >
-          <Button type="submit">Uložit</Button>
-          <Button color="secondary">Zrušit</Button>
-        </ActionGroup>
-      </Stack>
-    </Section>
-  </>
-);
+          {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
+                and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
+          <Box backgroundColor="primary" borderColor="basic" borderRadius="400" borderWidth="100" padding="space-900">
+            <FieldGroup
+              id="cv-driving-license-groups"
+              label="Skupiny řidičského průkazu"
+              isLabelHidden
+              {...(hasSimulatedErrors && {
+                validationState: 'danger',
+                validationText: 'Vyberte alespoň jednu skupinu řidičského průkazu.',
+              })}
+            >
+              <Grid cols={{ mobile: 1, tablet: 3 }} spacing="space-500">
+                {LICENSE_GROUPS.map(({ id, label }) => (
+                  <GridItem key={id}>
+                    <Checkbox id={`cv-driving-license-${id}`} name="drivingLicense" value={id} label={label} />
+                  </GridItem>
+                ))}
+              </Grid>
+            </FieldGroup>
+          </Box>
+          <ActionGroup
+            direction={{ mobile: 'vertical', tablet: 'horizontal-reversed' }}
+            alignmentX={{ mobile: 'stretch', tablet: 'left' }}
+            spacing="space-600"
+          >
+            <Button type="submit">Uložit</Button>
+            <Button color="secondary">Zrušit</Button>
+          </ActionGroup>
+        </Stack>
+      </Section>
+    </>
+  );
+};

--- a/packages/web-react/docs/stories/examples/CvEditorWorkExperience.stories.tsx
+++ b/packages/web-react/docs/stories/examples/CvEditorWorkExperience.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { type ChangeEvent, useState } from 'react';
 import {
   ActionGroup,
   Box,
@@ -15,6 +15,10 @@ import {
   Text,
   TextArea,
   TextField,
+  Toast,
+  ToastBar,
+  ToastBarMessage,
+  Toggle,
 } from '../../../src/components';
 
 const MONTHS = [
@@ -34,6 +38,12 @@ const MONTHS = [
 
 const CURRENT_YEAR = new Date().getFullYear();
 const YEARS = Array.from({ length: CURRENT_YEAR - 1949 }, (_, index) => String(CURRENT_YEAR - index));
+
+const DESCRIPTION_COUNTER_THRESHOLD = 5000;
+const DESCRIPTION_SENTENCE = 'Vedení týmu, plánování projektů a komunikace se zákazníky. ';
+const OVER_LIMIT_DESCRIPTION = DESCRIPTION_SENTENCE.repeat(
+  Math.ceil((DESCRIPTION_COUNTER_THRESHOLD + 1) / DESCRIPTION_SENTENCE.length),
+);
 
 const PROFESSIONAL_FIELDS = [
   { value: '1', label: 'Administrativa' },
@@ -85,11 +95,58 @@ export default {
   parameters: { layout: 'fullscreen' },
 };
 
+/**
+ * Interactive CV editor work experience page. The “Simulate validation errors” toggle puts the form
+ * into the state it has after a failed save — required fields in their `danger` state, an over-limit
+ * description and the error Toast — so the error design can be reviewed without filling the form in.
+ */
 export const CvEditorWorkExperience = () => {
   const [isCurrentlyWorking, setIsCurrentlyWorking] = useState(false);
+  const [hasSimulatedErrors, setHasSimulatedErrors] = useState(false);
+  const [isErrorToastOpen, setIsErrorToastOpen] = useState(false);
+  const [description, setDescription] = useState('');
+
+  const isDescriptionOverLimit = description.length > DESCRIPTION_COUNTER_THRESHOLD;
+
+  const handleSimulateErrorsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { checked } = event.target;
+
+    setHasSimulatedErrors(checked);
+    setIsErrorToastOpen(checked);
+    setDescription(checked ? OVER_LIMIT_DESCRIPTION : '');
+  };
 
   return (
     <>
+      <Toast alignmentX="center" alignmentY="top">
+        <ToastBar
+          id="cv-work-experience-error-toast"
+          color="danger"
+          onClose={() => setIsErrorToastOpen(false)}
+          hasIcon
+          isDismissible
+          isOpen={isErrorToastOpen}
+        >
+          <ToastBarMessage>Formulář se nepovedlo uložit. Zkontrolujte prosím zvýrazněná pole.</ToastBarMessage>
+        </ToastBar>
+      </Toast>
+      <Section elementType="div" size="small" containerProps={{ size: 'small' }}>
+        <Box
+          backgroundColor="emotion-informative-subtle"
+          borderColor="emotion-informative-basic"
+          borderWidth="100"
+          borderRadius="200"
+          padding="space-600"
+        >
+          <Toggle
+            id="cv-work-experience-simulate-errors"
+            label="Simulate validation errors"
+            isChecked={hasSimulatedErrors}
+            inputPosition="start"
+            onChange={handleSimulateErrorsChange}
+          />
+        </Box>
+      </Section>
       <Section
         elementType="div"
         size="small"
@@ -128,6 +185,7 @@ export const CvEditorWorkExperience = () => {
           onSubmit={(event) => event.preventDefault()}
           aria-labelledby="cv-work-experience-heading"
           spacing="space-1000"
+          noValidate
         >
           {/* TODO [DS-2774]: The design applies `shadow-100` on this card. `Box` has no `boxShadow` prop
                 and there is no shadow utility class in `web`, so the shadow is intentionally omitted here. */}
@@ -143,6 +201,10 @@ export const CvEditorWorkExperience = () => {
                   label="Název pracovní pozice"
                   autoComplete="organization-title"
                   isRequired
+                  {...(hasSimulatedErrors && {
+                    validationState: 'danger',
+                    validationText: 'Zadejte název pracovní pozice.',
+                  })}
                 />
               </GridItem>
               <GridItem>
@@ -152,10 +214,23 @@ export const CvEditorWorkExperience = () => {
                   label="Firma, instituce"
                   autoComplete="organization"
                   isRequired
+                  {...(hasSimulatedErrors && {
+                    validationState: 'danger',
+                    validationText: 'Zadejte název firmy nebo instituce.',
+                  })}
                 />
               </GridItem>
               <GridItem>
-                <Select id="work-experience-field" name="professionalField" label="Profesní obor" isRequired>
+                <Select
+                  id="work-experience-field"
+                  name="professionalField"
+                  label="Profesní obor"
+                  isRequired
+                  {...(hasSimulatedErrors && {
+                    validationState: 'danger',
+                    validationText: 'Vyberte profesní obor.',
+                  })}
+                >
                   <option value="">Vyberte</option>
                   {PROFESSIONAL_FIELDS.map(({ value, label }) => (
                     <option key={value} value={value}>
@@ -203,8 +278,14 @@ export const CvEditorWorkExperience = () => {
                   name="description"
                   label="Vaše pracovní zkušenosti"
                   placeholder="Co bylo hlavní náplní vaší práce?"
-                  counterThreshold={5000}
+                  counterThreshold={DESCRIPTION_COUNTER_THRESHOLD}
                   isAutoResizing
+                  value={description}
+                  onChange={(event: ChangeEvent<HTMLTextAreaElement>) => setDescription(event.target.value)}
+                  {...(isDescriptionOverLimit && {
+                    validationState: 'danger',
+                    validationText: `Vyplněný text je příliš dlouhý. Může obsahovat maximálně ${DESCRIPTION_COUNTER_THRESHOLD} znaků.`,
+                  })}
                 />
               </GridItem>
             </Grid>

--- a/packages/web/.browserslistrc
+++ b/packages/web/.browserslistrc
@@ -1,1 +1,1 @@
-extends @lmc-eu/browserslist-config
+extends @alma-oss/browserslist-config

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,11 +59,11 @@
     "@floating-ui/dom": "catalog:frontend"
   },
   "devDependencies": {
+    "@alma-oss/browserslist-config": "catalog:build",
     "@alma-oss/spirit-common": "workspace:^",
     "@babel/core": "catalog:build",
     "@eslint/compat": "catalog:lint",
     "@eslint/eslintrc": "catalog:lint",
-    "@lmc-eu/browserslist-config": "catalog:build",
     "@rollup/plugin-babel": "catalog:build",
     "@rollup/plugin-node-resolve": "catalog:build",
     "@rollup/plugin-replace": "catalog:build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,12 +12,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@alma-oss/browserslist-config@npm:3.0.0-alpha.0":
+  version: 3.0.0-alpha.0
+  resolution: "@alma-oss/browserslist-config@npm:3.0.0-alpha.0"
+  checksum: 10/231dd7adae0a2e56e8b64c070d2fd6777cdd9c7a9c457768340a105b6e8d009ddc403c80d17921e580c4bb2b887e912b043f68404b7f3d0dc9e0235b65dc9d15
+  languageName: node
+  linkType: hard
+
 "@alma-oss/commitlint-config@npm:3.0.0":
   version: 3.0.0
   resolution: "@alma-oss/commitlint-config@npm:3.0.0"
   dependencies:
     "@commitlint/config-conventional": "npm:^19.0.0"
   checksum: 10/7a269a664db580f7a10f3cb6d12bd2dce82b1f1892e73df30791b2fb262dff0edba0cc88d17907922c9efd0511c8be60bead0589be94a2f6c675b67e7d187cbb
+  languageName: node
+  linkType: hard
+
+"@alma-oss/remark-config@npm:1.0.0-alpha.0":
+  version: 1.0.0-alpha.0
+  resolution: "@alma-oss/remark-config@npm:1.0.0-alpha.0"
+  dependencies:
+    remark-preset-lint-consistent: "npm:^6.0.0"
+    remark-preset-lint-markdown-style-guide: "npm:^6.0.0"
+    remark-preset-lint-recommended: "npm:^7.0.0"
+  checksum: 10/678e5271f18d9569c314719172e67d68a74848da87efc4aa94168616f4398615432b077bc3acd3bc660239d3f7ed5c837c33cb39b0eba73079546758e5798011
   languageName: node
   linkType: hard
 
@@ -445,6 +463,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@alma-oss/spirit-web@workspace:packages/web"
   dependencies:
+    "@alma-oss/browserslist-config": "catalog:build"
     "@alma-oss/spirit-common": "workspace:^"
     "@alma-oss/spirit-design-tokens": "npm:^5.1.0"
     "@alma-oss/spirit-icons": "npm:^4.0.1"
@@ -453,7 +472,6 @@ __metadata:
     "@eslint/compat": "catalog:lint"
     "@eslint/eslintrc": "catalog:lint"
     "@floating-ui/dom": "catalog:frontend"
-    "@lmc-eu/browserslist-config": "catalog:build"
     "@rollup/plugin-babel": "catalog:build"
     "@rollup/plugin-node-resolve": "catalog:build"
     "@rollup/plugin-replace": "catalog:build"
@@ -490,6 +508,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@alma-oss/stylelint-config@npm:10.0.0-alpha.0":
+  version: 10.0.0-alpha.0
+  resolution: "@alma-oss/stylelint-config@npm:10.0.0-alpha.0"
+  dependencies:
+    postcss-scss: "npm:^4.0.3"
+    stylelint-config-standard-scss: "npm:^13.0.0"
+    stylelint-order: "npm:^6.0.0"
+  peerDependencies:
+    stylelint: ^16.0.0
+  checksum: 10/68b3eaa6735bee307d955ccfb65da8fc84686b92a95f1189d2d6e7def2858910aeb00e5f49c7aae13fe93a197b361bfc2d353ca65bac3505790cd2cf4acf66b5
+  languageName: node
+  linkType: hard
+
 "@alma-oss/vite-plugin-spirit-icons@workspace:^, @alma-oss/vite-plugin-spirit-icons@workspace:packages/vite-plugin-spirit-icons":
   version: 0.0.0-use.local
   resolution: "@alma-oss/vite-plugin-spirit-icons@workspace:packages/vite-plugin-spirit-icons"
@@ -511,30 +542,6 @@ __metadata:
     vite: ">=5"
   languageName: unknown
   linkType: soft
-
-"@almacareer/remark-config@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@almacareer/remark-config@npm:0.1.0"
-  dependencies:
-    remark-preset-lint-consistent: "npm:^6.0.0"
-    remark-preset-lint-markdown-style-guide: "npm:^6.0.0"
-    remark-preset-lint-recommended: "npm:^7.0.0"
-  checksum: 10/5fc4a6eead07286ad28a410395cc4deb8deb21a05a19624856bd82f491316a74243410193d006e8bcc7049779a8ce58141f0e7268f0dae741b173a978d995aea
-  languageName: node
-  linkType: hard
-
-"@almacareer/stylelint-config@npm:9.1.3":
-  version: 9.1.3
-  resolution: "@almacareer/stylelint-config@npm:9.1.3"
-  dependencies:
-    postcss-scss: "npm:^4.0.3"
-    stylelint-config-standard-scss: "npm:^13.0.0"
-    stylelint-order: "npm:^6.0.0"
-  peerDependencies:
-    stylelint: ^16.0.0
-  checksum: 10/8af3216ffb50411f1d2c035e543c692b26a6ef7bec348aa883dde31e66e1ea0ac7bba8d9c9ec7061bb7d265120721ce8a9a9f89b2a6f363646cab901d6cd2e48
-  languageName: node
-  linkType: hard
 
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
@@ -6683,13 +6690,6 @@ __metadata:
   version: 1.1.1
   resolution: "@kwsites/promise-deferred@npm:1.1.1"
   checksum: 10/07455477a0123d9a38afb503739eeff2c5424afa8d3dbdcc7f9502f13604488a4b1d9742fc7288832a52a6422cf1e1c0a1d51f69a39052f14d27c9a0420b6629
-  languageName: node
-  linkType: hard
-
-"@lmc-eu/browserslist-config@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@lmc-eu/browserslist-config@npm:2.0.1"
-  checksum: 10/94f1cd729b321cf3d6b46b39d7479ed9442af24f14c4e1cce1abfa1c922081ee4736a57609c41d77c7059ea99243fcc6d9ff2770508982dfa72245614fdc5379
   languageName: node
   linkType: hard
 
@@ -35418,7 +35418,7 @@ __metadata:
   resolution: "spirit@workspace:."
   dependencies:
     "@alma-oss/commitlint-config": "catalog:lint"
-    "@almacareer/remark-config": "catalog:lint"
+    "@alma-oss/remark-config": "catalog:lint"
     "@axe-core/playwright": "catalog:test"
     "@commitlint/cli": "catalog:lint"
     "@eslint/compat": "catalog:lint"
@@ -36138,7 +36138,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "stylelint-config-spirit@workspace:configs/stylelint-config-spirit"
   dependencies:
-    "@almacareer/stylelint-config": "catalog:lint"
+    "@alma-oss/stylelint-config": "catalog:lint"
     prettier: "catalog:lint"
     stylelint: "catalog:lint"
     stylelint-order: "catalog:lint"


### PR DESCRIPTION
## Description

The shared `@lmc-eu/browserslist-config` and `@almacareer/remark-config`/`stylelint-config` packages are being retired in favor of their `@alma-oss`-scoped replacements as part of the org-wide package migration. This PR swaps all three references (Yarn catalog, `package.json` deps, and the config files that import them) to the new scope.

### Additional context

Only alpha versions are currently published for the `@alma-oss` replacements (`browserslist-config@3.0.0-alpha.0`, `remark-config@1.0.0-alpha.0`, `stylelint-config@10.0.0-alpha.0`) — pinned exact alpha versions for now; will bump once stable releases land. Also added `.browserslistrc` to `.prettierignore`, since Prettier has no parser for that file format and it was failing the pre-commit hook on this change.

### Issue reference

<!-- Please insert a link to the solved issue. If none, create one for this PR and then reference it here -->